### PR TITLE
개별 질문 조회 기능 구현 

### DIFF
--- a/domain/mathrank-problem-single-read-domain/build.gradle
+++ b/domain/mathrank-problem-single-read-domain/build.gradle
@@ -9,4 +9,28 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
 
     implementation project(':domain:mathrank-problem-core-domain')
+
+    // query dsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+}
+
+def querydslSrcDir = 'src/main/generated'
+
+clean {
+    delete file(querydslSrcDir)
+}
+
+tasks.withType(JavaCompile) {
+    options.generatedSourceOutputDirectory = file(querydslSrcDir)
+}
+
+sourceSets {
+    main {
+        java {
+            srcDirs += querydslSrcDir
+        }
+    }
 }

--- a/domain/mathrank-problem-single-read-domain/build.gradle
+++ b/domain/mathrank-problem-single-read-domain/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
     testImplementation 'org.testcontainers:junit-jupiter'
@@ -9,6 +10,8 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
 
     implementation project(':domain:mathrank-problem-core-domain')
+
+    implementation project(':common:mathrank-page')
 
     // query dsl
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/SingleProblemReadModelConfiguration.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/SingleProblemReadModelConfiguration.java
@@ -1,0 +1,20 @@
+package kr.co.mathrank.domain.problem.single.read;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+@Configuration
+class SingleProblemReadModelConfiguration {
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory() {
+		return new JPAQueryFactory(entityManager);
+	}
+}

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/dto/SingleProblemReadModelPageResult.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/dto/SingleProblemReadModelPageResult.java
@@ -1,0 +1,11 @@
+package kr.co.mathrank.domain.problem.single.read.dto;
+
+import java.util.List;
+
+public record SingleProblemReadModelPageResult(
+	List<SingleProblemReadModelResult> queryResults,
+	Integer currentPageNumber,
+	Integer currentPageSize,
+	List<Integer> possibleNextPageNumbers
+) {
+}

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/dto/SingleProblemReadModelQuery.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/dto/SingleProblemReadModelQuery.java
@@ -1,0 +1,22 @@
+package kr.co.mathrank.domain.problem.single.read.dto;
+
+import kr.co.mathrank.domain.problem.core.AnswerType;
+import kr.co.mathrank.domain.problem.core.Difficulty;
+
+public record SingleProblemReadModelQuery(
+	Long singleProblemId,
+
+	String coursePath,
+
+	AnswerType answerType,
+
+	Difficulty difficultyMinInclude,
+	Difficulty difficultyMaxInclude,
+
+	Integer accuracyMinInclude,
+	Integer accuracyMaxInclude,
+
+	Long totalAttemptCountMinInclude,
+	Long totalAttemptCountMaxInclude
+) {
+}

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/dto/SingleProblemReadModelResult.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/dto/SingleProblemReadModelResult.java
@@ -1,0 +1,33 @@
+package kr.co.mathrank.domain.problem.single.read.dto;
+
+import kr.co.mathrank.domain.problem.core.AnswerType;
+import kr.co.mathrank.domain.problem.core.Difficulty;
+import kr.co.mathrank.domain.problem.single.read.entity.SingleProblemReadModel;
+
+public record SingleProblemReadModelResult(
+	Long id, // single problem id
+	Long problemId, // problem id
+	String problemImage,
+	String coursePath,
+	AnswerType answerType,
+	Difficulty difficulty,
+	Long firstTrySuccessCount, // 첫번째 시도에서 성공한 횟수
+	Long totalAttemptedCount, // 문제를 풀려고 시도한 총 횟수
+	Long attemptedUserDistinctCount, // 해당 문제를 풀려고 한 사용자 수
+	Double accuracy // 정답률
+) {
+	public static SingleProblemReadModelResult from(final SingleProblemReadModel model) {
+		return new SingleProblemReadModelResult(
+			model.getId(),
+			model.getProblemId(),
+			model.getProblemImage(),
+			model.getCoursePath(),
+			model.getAnswerType(),
+			model.getDifficulty(),
+			model.getFirstTrySuccessCount(),
+			model.getTotalAttemptedCount(),
+			model.getAttemptedUserDistinctCount(),
+			model.getAccuracy()
+		);
+	}
+}

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/repository/SingleProblemReadModelQueryRepository.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/repository/SingleProblemReadModelQueryRepository.java
@@ -1,0 +1,11 @@
+package kr.co.mathrank.domain.problem.single.read.repository;
+
+import java.util.List;
+
+import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemReadModelQuery;
+import kr.co.mathrank.domain.problem.single.read.entity.SingleProblemReadModel;
+
+interface SingleProblemReadModelQueryRepository {
+	List<SingleProblemReadModel> queryPage(SingleProblemReadModelQuery query, int pageSize, int pageNumber);
+	Long count(SingleProblemReadModelQuery query);
+}

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/repository/SingleProblemReadModelQueryRepositoryImpl.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/repository/SingleProblemReadModelQueryRepositoryImpl.java
@@ -27,12 +27,7 @@ class SingleProblemReadModelQueryRepositoryImpl implements SingleProblemReadMode
 		return queryFactory.select(model)
 			.from(model)
 			.where(
-				singleProblemIdMatch(query.singleProblemId()),
-				difficultyIn(query.difficultyMinInclude(), query.difficultyMaxInclude()),
-				coursePathMatch(query.coursePath()),
-				answerTypeEqual(query.answerType()),
-				accuracyIn(query.accuracyMinInclude(), query.accuracyMaxInclude()),
-				totalAttemptCountIn(query.totalAttemptCountMinInclude(), query.totalAttemptCountMaxInclude())
+				createWherePredicates(query)
 			)
 			.offset((pageNumber - 1) * pageSize)
 			.limit(pageSize)
@@ -45,14 +40,20 @@ class SingleProblemReadModelQueryRepositoryImpl implements SingleProblemReadMode
 		return queryFactory.select(model.count())
 			.from(model)
 			.where(
-				singleProblemIdMatch(query.singleProblemId()),
-				difficultyIn(query.difficultyMinInclude(), query.difficultyMaxInclude()),
-				coursePathMatch(query.coursePath()),
-				answerTypeEqual(query.answerType()),
-				accuracyIn(query.accuracyMinInclude(), query.accuracyMaxInclude()),
-				totalAttemptCountIn(query.totalAttemptCountMinInclude(), query.totalAttemptCountMaxInclude())
+				createWherePredicates(query)
 			)
 			.fetchOne();
+	}
+
+	private BooleanExpression[] createWherePredicates(SingleProblemReadModelQuery query) {
+		return new BooleanExpression[] {
+			singleProblemIdMatch(query.singleProblemId()),
+			difficultyIn(query.difficultyMinInclude(), query.difficultyMaxInclude()),
+			coursePathMatch(query.coursePath()),
+			accuracyIn(query.accuracyMinInclude(), query.accuracyMaxInclude()),
+			totalAttemptCountIn(query.totalAttemptCountMinInclude(), query.totalAttemptCountMaxInclude()),
+			answerTypeEqual(query.answerType()),
+		};
 	}
 
 	private BooleanExpression singleProblemIdMatch(final Long singleProblemId) {

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/repository/SingleProblemReadModelQueryRepositoryImpl.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/repository/SingleProblemReadModelQueryRepositoryImpl.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Repository;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
+import kr.co.mathrank.domain.problem.core.AnswerType;
 import kr.co.mathrank.domain.problem.core.Difficulty;
 import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemReadModelQuery;
 import kr.co.mathrank.domain.problem.single.read.entity.QSingleProblemReadModel;
@@ -29,6 +30,7 @@ class SingleProblemReadModelQueryRepositoryImpl implements SingleProblemReadMode
 				singleProblemIdMatch(query.singleProblemId()),
 				diffcultyIn(query.difficultyMinInclude(), query.difficultyMaxInclude()),
 				coursePathMatch(query.coursePath()),
+				answerTypeEqual(query.answerType()),
 				accuracyIn(query.accuracyMinInclude(), query.accuracyMaxInclude()),
 				totalAttemptCountIn(query.totalAttemptCountMinInclude(), query.totalAttemptCountMaxInclude())
 			)
@@ -46,6 +48,7 @@ class SingleProblemReadModelQueryRepositoryImpl implements SingleProblemReadMode
 				singleProblemIdMatch(query.singleProblemId()),
 				diffcultyIn(query.difficultyMinInclude(), query.difficultyMaxInclude()),
 				coursePathMatch(query.coursePath()),
+				answerTypeEqual(query.answerType()),
 				accuracyIn(query.accuracyMinInclude(), query.accuracyMaxInclude()),
 				totalAttemptCountIn(query.totalAttemptCountMinInclude(), query.totalAttemptCountMaxInclude())
 			)
@@ -90,5 +93,13 @@ class SingleProblemReadModelQueryRepositoryImpl implements SingleProblemReadMode
 		}
 
 		return QSingleProblemReadModel.singleProblemReadModel.totalAttemptedCount.between(attemptCountMinInclude, attemptCountMaxInclude);
+	}
+
+	private BooleanExpression answerTypeEqual(final AnswerType answerType) {
+		if (answerType == null) {
+			return null;
+		}
+
+		return QSingleProblemReadModel.singleProblemReadModel.answerType.eq(answerType);
 	}
 }

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/repository/SingleProblemReadModelQueryRepositoryImpl.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/repository/SingleProblemReadModelQueryRepositoryImpl.java
@@ -1,0 +1,94 @@
+package kr.co.mathrank.domain.problem.single.read.repository;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import kr.co.mathrank.domain.problem.core.Difficulty;
+import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemReadModelQuery;
+import kr.co.mathrank.domain.problem.single.read.entity.QSingleProblemReadModel;
+import kr.co.mathrank.domain.problem.single.read.entity.SingleProblemReadModel;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+class SingleProblemReadModelQueryRepositoryImpl implements SingleProblemReadModelQueryRepository {
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public List<SingleProblemReadModel> queryPage(SingleProblemReadModelQuery query, int pageSize,
+		int pageNumber) {
+		final QSingleProblemReadModel model = QSingleProblemReadModel.singleProblemReadModel;
+
+		return queryFactory.select(model)
+			.from(model)
+			.where(
+				singleProblemIdMatch(query.singleProblemId()),
+				diffcultyIn(query.difficultyMinInclude(), query.difficultyMaxInclude()),
+				coursePathMatch(query.coursePath()),
+				accuracyIn(query.accuracyMinInclude(), query.accuracyMaxInclude()),
+				totalAttemptCountIn(query.totalAttemptCountMinInclude(), query.totalAttemptCountMaxInclude())
+			)
+			.offset((pageNumber - 1) * pageSize)
+			.limit(pageSize)
+			.fetch();
+	}
+
+	@Override
+	public Long count(SingleProblemReadModelQuery query) {
+		final QSingleProblemReadModel model = QSingleProblemReadModel.singleProblemReadModel;
+		return queryFactory.select(model.count())
+			.from(model)
+			.where(
+				singleProblemIdMatch(query.singleProblemId()),
+				diffcultyIn(query.difficultyMinInclude(), query.difficultyMaxInclude()),
+				coursePathMatch(query.coursePath()),
+				accuracyIn(query.accuracyMinInclude(), query.accuracyMaxInclude()),
+				totalAttemptCountIn(query.totalAttemptCountMinInclude(), query.totalAttemptCountMaxInclude())
+			)
+			.fetchOne();
+	}
+
+	private BooleanExpression singleProblemIdMatch(final Long singleProblemId) {
+		if (singleProblemId == null) {
+			return null;
+		}
+
+		return QSingleProblemReadModel.singleProblemReadModel.id.eq(singleProblemId);
+	}
+
+	private BooleanExpression diffcultyIn(final Difficulty difficultyMinInclude, final Difficulty difficultyMaxInclude) {
+		if (difficultyMinInclude == null && difficultyMaxInclude == null) {
+			return null;
+		}
+
+		return QSingleProblemReadModel.singleProblemReadModel.difficulty.between(difficultyMinInclude, difficultyMaxInclude);
+	}
+
+	private BooleanExpression coursePathMatch(final String coursePath) {
+		if (coursePath == null) {
+			return null;
+		}
+
+		return QSingleProblemReadModel.singleProblemReadModel.coursePath.startsWith(coursePath);
+	}
+
+	private BooleanExpression accuracyIn(final Integer accuracyMinInclude, final Integer accuracyMaxInclude) {
+		if (accuracyMinInclude == null && accuracyMaxInclude == null) {
+			return null;
+		}
+
+		return QSingleProblemReadModel.singleProblemReadModel.accuracy.between(accuracyMinInclude, accuracyMaxInclude);
+	}
+
+	private BooleanExpression totalAttemptCountIn(final Long attemptCountMinInclude, final Long attemptCountMaxInclude) {
+		if (attemptCountMinInclude == null && attemptCountMaxInclude == null) {
+			return null;
+		}
+
+		return QSingleProblemReadModel.singleProblemReadModel.totalAttemptedCount.between(attemptCountMinInclude, attemptCountMaxInclude);
+	}
+}

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/repository/SingleProblemReadModelQueryRepositoryImpl.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/repository/SingleProblemReadModelQueryRepositoryImpl.java
@@ -28,7 +28,7 @@ class SingleProblemReadModelQueryRepositoryImpl implements SingleProblemReadMode
 			.from(model)
 			.where(
 				singleProblemIdMatch(query.singleProblemId()),
-				diffcultyIn(query.difficultyMinInclude(), query.difficultyMaxInclude()),
+				difficultyIn(query.difficultyMinInclude(), query.difficultyMaxInclude()),
 				coursePathMatch(query.coursePath()),
 				answerTypeEqual(query.answerType()),
 				accuracyIn(query.accuracyMinInclude(), query.accuracyMaxInclude()),
@@ -46,7 +46,7 @@ class SingleProblemReadModelQueryRepositoryImpl implements SingleProblemReadMode
 			.from(model)
 			.where(
 				singleProblemIdMatch(query.singleProblemId()),
-				diffcultyIn(query.difficultyMinInclude(), query.difficultyMaxInclude()),
+				difficultyIn(query.difficultyMinInclude(), query.difficultyMaxInclude()),
 				coursePathMatch(query.coursePath()),
 				answerTypeEqual(query.answerType()),
 				accuracyIn(query.accuracyMinInclude(), query.accuracyMaxInclude()),
@@ -63,7 +63,7 @@ class SingleProblemReadModelQueryRepositoryImpl implements SingleProblemReadMode
 		return QSingleProblemReadModel.singleProblemReadModel.id.eq(singleProblemId);
 	}
 
-	private BooleanExpression diffcultyIn(final Difficulty difficultyMinInclude, final Difficulty difficultyMaxInclude) {
+	private BooleanExpression difficultyIn(final Difficulty difficultyMinInclude, final Difficulty difficultyMaxInclude) {
 		if (difficultyMinInclude == null && difficultyMaxInclude == null) {
 			return null;
 		}

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/repository/SingleProblemReadModelRepository.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/repository/SingleProblemReadModelRepository.java
@@ -4,5 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import kr.co.mathrank.domain.problem.single.read.entity.SingleProblemReadModel;
 
-public interface SingleProblemReadModelRepository extends JpaRepository<SingleProblemReadModel, Long> {
+public interface SingleProblemReadModelRepository
+	extends JpaRepository<SingleProblemReadModel, Long>, SingleProblemReadModelQueryRepository {
 }

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemQueryService.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemQueryService.java
@@ -1,0 +1,42 @@
+package kr.co.mathrank.domain.problem.single.read.service;
+
+import java.util.List;
+
+import org.hibernate.validator.constraints.Range;
+import org.springframework.stereotype.Service;
+import org.springframework.validation.annotation.Validated;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import kr.co.mathrank.common.page.PageUtil;
+import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemReadModelPageResult;
+import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemReadModelQuery;
+import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemReadModelResult;
+import kr.co.mathrank.domain.problem.single.read.entity.SingleProblemReadModel;
+import kr.co.mathrank.domain.problem.single.read.repository.SingleProblemReadModelRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Validated
+@RequiredArgsConstructor
+public class SingleProblemQueryService {
+	private final SingleProblemReadModelRepository singleProblemRepository;
+
+	public SingleProblemReadModelPageResult queryPage(
+		@NotNull @Valid final SingleProblemReadModelQuery query,
+		@NotNull @Range(min = 1, max = 100) final Integer pageSize,
+		@NotNull @Range(max = 2000) final Integer pageNumber
+	) {
+		final List<SingleProblemReadModel> readModels = singleProblemRepository.queryPage(query, pageSize, pageNumber);
+		final Long count = singleProblemRepository.count(query);
+
+		return new SingleProblemReadModelPageResult(
+			readModels.stream()
+				.map(SingleProblemReadModelResult::from)
+				.toList(),
+			pageNumber,
+			pageSize,
+			PageUtil.getNextPages(pageSize, pageNumber, count, readModels.size()
+			));
+	}
+}

--- a/domain/mathrank-problem-single-read-domain/src/test/java/kr/co/mathrank/domain/problem/single/read/repository/SingleProblemReadModelRepositoryTest.java
+++ b/domain/mathrank-problem-single-read-domain/src/test/java/kr/co/mathrank/domain/problem/single/read/repository/SingleProblemReadModelRepositoryTest.java
@@ -1,0 +1,333 @@
+package kr.co.mathrank.domain.problem.single.read.repository;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import kr.co.mathrank.domain.problem.core.AnswerType;
+import kr.co.mathrank.domain.problem.core.Difficulty;
+import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemReadModelQuery;
+import kr.co.mathrank.domain.problem.single.read.entity.SingleProblemReadModel;
+
+@Transactional
+@SpringBootTest(
+	properties =
+		"""
+			spring.jpa.show-sql=true
+			spring.jpa.hibernate.ddl-auto=create
+			"""
+)
+@Testcontainers
+class SingleProblemReadModelRepositoryTest {
+	@Autowired
+	private SingleProblemReadModelRepository singleProblemReadModelRepository;
+
+	@Container
+	static MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0.42")
+		.withDatabaseName("testdb")
+		.withUsername("user")
+		.withPassword("password");
+
+	@DynamicPropertySource
+	static void setProperties(DynamicPropertyRegistry registry) {
+		registry.add("spring.datasource.url", mysql::getJdbcUrl);
+		registry.add("spring.datasource.username", mysql::getUsername);
+		registry.add("spring.datasource.password", mysql::getPassword);
+	}
+
+	@Test
+	void 난이도를_조건으로_검색한다() {
+		singleProblemReadModelRepository.saveAll(List.of(
+			SingleProblemReadModel.of(
+				1L,
+				1L,
+				"testImage",
+				"path",
+				AnswerType.MULTIPLE_CHOICE,
+				Difficulty.KILLER, // 가중치 60
+				100L,
+				2000L,
+				1000L
+			),
+			SingleProblemReadModel.of(
+				2L,
+				2L,
+				"testImage",
+				"path",
+				AnswerType.MULTIPLE_CHOICE,
+				Difficulty.MID, // 가중치 30
+				100L,
+				2000L,
+				1000L
+			),
+			SingleProblemReadModel.of(
+				3L,
+				3L,
+				"testImage",
+				"path",
+				AnswerType.MULTIPLE_CHOICE,
+				Difficulty.LOW, // 가중치 10
+				100L,
+				2000L,
+				1000L
+			)
+		));
+
+		Assertions.assertAll(
+			// MID 이상의 결과는 두개여야 한다.
+			() -> Assertions.assertEquals(2, singleProblemReadModelRepository.queryPage(
+				new SingleProblemReadModelQuery(
+					null,
+					null,
+					null,
+					Difficulty.MID,
+					Difficulty.KILLER,
+					null,
+					null,
+					null,
+					null
+				),
+				10,
+				1
+			).size()),
+			// 한쪽 조건이 null 일시, 모두 포함한다
+			() -> Assertions.assertEquals(2, singleProblemReadModelRepository.queryPage(
+				new SingleProblemReadModelQuery(
+					null,
+					null,
+					null,
+					Difficulty.MID,
+					null,
+					null,
+					null,
+					null,
+					null
+				),
+				10,
+				1
+			).size()),
+			// max, min 이 같을땐 하나가 리턴되야 한다
+			() -> Assertions.assertEquals(1, singleProblemReadModelRepository.queryPage(
+				new SingleProblemReadModelQuery(
+					null,
+					null,
+					null,
+					Difficulty.MID,
+					Difficulty.MID,
+					null,
+					null,
+					null,
+					null
+				),
+				10,
+				1
+			).size())
+		);
+	}
+
+	@Test
+	void 정답률을_조건으로_검색한다() {
+		singleProblemReadModelRepository.saveAll(List.of(
+
+			// 정답률 10
+			SingleProblemReadModel.of(
+				1L,
+				1L,
+				"testImage",
+				"path",
+				null,
+				null,
+				100L,
+				2000L,
+				1000L
+			),
+
+			// 정답률 20
+			SingleProblemReadModel.of(
+				2L,
+				2L,
+				"testImage",
+				"path",
+				null,
+				null,
+				200L,
+				2000L,
+				1000L
+			),
+
+			// 정답률 30
+			SingleProblemReadModel.of(
+				3L,
+				3L,
+				"testImage",
+				"path",
+				null,
+				null,
+				300L,
+				2000L,
+				1000L
+			)
+		));
+
+		Assertions.assertAll(
+			// 10 ~ 30 사이는 3개
+			() -> Assertions.assertEquals(3, singleProblemReadModelRepository.queryPage(
+				new SingleProblemReadModelQuery(
+					null,
+					null,
+					null,
+					null,
+					null,
+					10,
+					30,
+					null,
+					null
+				),
+				10,
+				1
+			).size()),
+			// 10 ~ 20은 두개
+			() -> Assertions.assertEquals(2, singleProblemReadModelRepository.queryPage(
+				new SingleProblemReadModelQuery(
+					null,
+					null,
+					null,
+					null,
+					null,
+					10,
+					20,
+					null,
+					null
+				),
+				10,
+				1
+			).size())
+		);
+	}
+
+	@Test
+	void 코스경로를_조건으로_검색한다() {
+		singleProblemReadModelRepository.saveAll(List.of(
+			SingleProblemReadModel.of(1L, 1L, "image", "math/algebra", null, null, 100L, 200L, 100L),
+			SingleProblemReadModel.of(2L, 2L, "image", "math/geometry", null, null, 100L, 200L, 100L),
+			SingleProblemReadModel.of(3L, 3L, "image", "science/physics", null, null, 100L, 200L, 100L)
+		));
+
+		Assertions.assertAll(
+			// math로 시작하는 것만
+			() -> Assertions.assertEquals(2, singleProblemReadModelRepository.queryPage(
+				new SingleProblemReadModelQuery(
+					null, "math", null, null, null,
+					null, null, null, null
+				),
+				10, 1
+			).size()),
+
+			// science로 시작하는 것만
+			() -> Assertions.assertEquals(1, singleProblemReadModelRepository.queryPage(
+				new SingleProblemReadModelQuery(
+					null, "science", null, null, null,
+					null, null, null, null
+				),
+				10, 1
+			).size()),
+
+			// 존재하지 않는 경로
+			() -> Assertions.assertEquals(0, singleProblemReadModelRepository.queryPage(
+				new SingleProblemReadModelQuery(
+					null, "english", null, null, null,
+					null, null, null, null
+				),
+				10, 1
+			).size())
+		);
+	}
+
+	@Test
+	void 시도수를_조건으로_검색한다() {
+		singleProblemReadModelRepository.saveAll(List.of(
+			SingleProblemReadModel.of(1L, 1L, "image", "path", null, null, 100L, 200L, 100L),
+			// totalAttemptedCount = 200
+			SingleProblemReadModel.of(2L, 2L, "image", "path", null, null, 100L, 300L, 100L),
+			// totalAttemptedCount = 300
+			SingleProblemReadModel.of(3L, 3L, "image", "path", null, null, 100L, 500L, 100L)
+			// totalAttemptedCount = 500
+		));
+
+		Assertions.assertAll(
+			// 200~300이면 두 개
+			() -> Assertions.assertEquals(2, singleProblemReadModelRepository.queryPage(
+				new SingleProblemReadModelQuery(
+					null, null, null, null, null,
+					null, null,
+					200L, 300L
+				),
+				10, 1
+			).size()),
+
+			// 최대값만 지정 시 500 이하 전부
+			() -> Assertions.assertEquals(3, singleProblemReadModelRepository.queryPage(
+				new SingleProblemReadModelQuery(
+					null, null, null, null, null,
+					null, null,
+					null, 500L
+				),
+				10, 1
+			).size()),
+
+			// 400 이상은 하나만
+			() -> Assertions.assertEquals(1, singleProblemReadModelRepository.queryPage(
+				new SingleProblemReadModelQuery(
+					null, null, null, null, null,
+					null, null,
+					400L, null
+				),
+				10, 1
+			).size())
+		);
+	}
+
+	@Test
+	void 복합조건으로_검색한다() {
+		singleProblemReadModelRepository.saveAll(List.of(
+			// 해당 조건에 부합 (정답률 30, 시도수 500, 난이도 MID, 코스 "math")
+			SingleProblemReadModel.of(1L, 1L, "image", "math/algebra", null, Difficulty.MID, 300L, 500L, 1000L),
+
+			// 정답률 미달 (20)
+			SingleProblemReadModel.of(2L, 2L, "image", "math/algebra", null, Difficulty.MID, 200L, 500L, 1000L),
+
+			// 시도수 초과 (600)
+			SingleProblemReadModel.of(3L, 3L, "image", "math/algebra", null, Difficulty.MID, 300L, 600L, 1000L),
+
+			// 난이도 다름 (LOW)
+			SingleProblemReadModel.of(4L, 4L, "image", "math/algebra", null, Difficulty.LOW, 300L, 500L, 1000L),
+
+			// 코스경로 다름 ("science")
+			SingleProblemReadModel.of(5L, 5L, "image", "science/physics", null, Difficulty.MID, 300L, 500L, 1000L)
+		));
+
+		// 조건: 정답률 [30~30], 시도수 [500~500], 난이도 MID, 코스경로 "math"
+		final SingleProblemReadModelQuery query = new SingleProblemReadModelQuery(
+			null, // id
+			"math", // coursePath startsWith
+			null, // problemId
+			Difficulty.MID,
+			Difficulty.MID,
+			30, // accuracy min
+			30, // accuracy max
+			500L, // attempt count min
+			500L  // attempt count max
+		);
+
+		Assertions.assertEquals(1, singleProblemReadModelRepository.queryPage(query, 10, 1).size());
+	}
+}

--- a/domain/mathrank-problem-single-read-domain/src/test/java/kr/co/mathrank/domain/problem/single/read/repository/SingleProblemReadModelRepositoryTest.java
+++ b/domain/mathrank-problem-single-read-domain/src/test/java/kr/co/mathrank/domain/problem/single/read/repository/SingleProblemReadModelRepositoryTest.java
@@ -317,15 +317,15 @@ class SingleProblemReadModelRepositoryTest {
 
 		// 조건: 정답률 [30~30], 시도수 [500~500], 난이도 MID, 코스경로 "math"
 		final SingleProblemReadModelQuery query = new SingleProblemReadModelQuery(
-			null, // id
-			"math", // coursePath startsWith
-			null, // problemId
+			null,
+			"math",
+			null,
 			Difficulty.MID,
 			Difficulty.MID,
-			30, // accuracy min
-			30, // accuracy max
-			500L, // attempt count min
-			500L  // attempt count max
+			30,
+			30,
+			500L,
+			500L
 		);
 
 		Assertions.assertEquals(1, singleProblemReadModelRepository.queryPage(query, 10, 1).size());

--- a/domain/mathrank-problem-single-read-domain/src/test/java/kr/co/mathrank/domain/problem/single/read/repository/SingleProblemReadModelRepositoryTest.java
+++ b/domain/mathrank-problem-single-read-domain/src/test/java/kr/co/mathrank/domain/problem/single/read/repository/SingleProblemReadModelRepositoryTest.java
@@ -330,4 +330,49 @@ class SingleProblemReadModelRepositoryTest {
 
 		Assertions.assertEquals(1, singleProblemReadModelRepository.queryPage(query, 10, 1).size());
 	}
+
+	@Test
+	void 정답유형을_조건으로_검색한다() {
+		singleProblemReadModelRepository.saveAll(List.of(
+			SingleProblemReadModel.of(1L, 1L, "image", "path", AnswerType.MULTIPLE_CHOICE, null, 100L, 200L, 100L),
+			SingleProblemReadModel.of(2L, 2L, "image", "path", AnswerType.MULTIPLE_CHOICE, null, 100L, 200L, 100L),
+			SingleProblemReadModel.of(3L, 3L, "image", "path", AnswerType.SHORT_ANSWER, null, 100L, 200L, 100L)
+		));
+
+		Assertions.assertAll(
+			// MULTIPLE_CHOICE만 검색하면 2개
+			() -> Assertions.assertEquals(2, singleProblemReadModelRepository.queryPage(
+				new SingleProblemReadModelQuery(
+					null, null, AnswerType.MULTIPLE_CHOICE, null, null,
+					null, null, null, null
+				), 10, 1
+			).size()),
+
+			// SHORT_ANSWER만 검색하면 1개
+			() -> Assertions.assertEquals(1, singleProblemReadModelRepository.queryPage(
+				new SingleProblemReadModelQuery(
+					null, null, AnswerType.SHORT_ANSWER, null, null,
+					null, null, null, null
+				),
+				10, 1
+			).size()),
+
+			// null로하면 모두 조회 ( 3개 )
+			() -> Assertions.assertEquals(3, singleProblemReadModelRepository.queryPage(
+				new SingleProblemReadModelQuery(
+					null,
+					null,
+					null,
+					null,
+					null,
+					null,
+					null,
+					null,
+					null
+					),
+				10, 1
+			).size())
+		);
+	}
+
 }

--- a/domain/mathrank-problem-single-read-domain/src/test/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemQueryServiceTest.java
+++ b/domain/mathrank-problem-single-read-domain/src/test/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemQueryServiceTest.java
@@ -1,0 +1,96 @@
+package kr.co.mathrank.domain.problem.single.read.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import kr.co.mathrank.domain.problem.core.Difficulty;
+import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemReadModelPageResult;
+import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemReadModelQuery;
+import kr.co.mathrank.domain.problem.single.read.entity.SingleProblemReadModel;
+import kr.co.mathrank.domain.problem.single.read.repository.SingleProblemReadModelRepository;
+
+@SpringBootTest(
+	properties = {
+		"spring.jpa.show-sql=true",
+		"spring.jpa.hibernate.ddl-auto=create"
+	}
+)
+@Testcontainers
+@Transactional
+class SingleProblemQueryServiceTest {
+
+	@Autowired
+	private SingleProblemQueryService queryService;
+
+	@Autowired
+	private SingleProblemReadModelRepository repository;
+
+	@Container
+	static MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0.42")
+		.withDatabaseName("testdb")
+		.withUsername("user")
+		.withPassword("password");
+
+	@DynamicPropertySource
+	static void setProperties(DynamicPropertyRegistry registry) {
+		registry.add("spring.datasource.url", mysql::getJdbcUrl);
+		registry.add("spring.datasource.username", mysql::getUsername);
+		registry.add("spring.datasource.password", mysql::getPassword);
+	}
+
+	@Test
+	void 정답률과_난이도조건으로_페이징_조회한다() {
+		// Given
+		repository.saveAll(List.of(
+			// 정답률 30
+			SingleProblemReadModel.of(1L, 1L, "img", "math", null, Difficulty.MID, 300L, 2000L, 1000L),
+			// 정답률 10
+			SingleProblemReadModel.of(2L, 2L, "img", "math", null, Difficulty.MID, 100L, 2000L, 1000L),
+			// 정답률 20
+			SingleProblemReadModel.of(3L, 3L, "img", "math", null, Difficulty.MID, 200L, 2000L, 1000L)
+		));
+
+		final SingleProblemReadModelQuery query = new SingleProblemReadModelQuery(
+			null,
+			"math",
+			null,
+			Difficulty.MID,
+			Difficulty.MID,
+			10,
+			30,
+			null,
+			null
+		);
+
+		// When
+		final SingleProblemReadModelPageResult result = queryService.queryPage(query, 2, 1);
+
+		// Then
+		// 두개가 나와야 한다
+		Assertions.assertEquals(2, result.queryResults().size()); // 페이지당 2개
+		Assertions.assertEquals(1, result.currentPageNumber()); // 페이지 번호
+		Assertions.assertEquals(2, result.currentPageSize()); // 페이지 크기
+		Assertions.assertEquals(1, result.possibleNextPageNumbers().size()); // 다음 페이지가 1개 존재한다
+
+		// 다음 페이지도 테스트
+		final SingleProblemReadModelPageResult nextResult = queryService.queryPage(query, 2, 2);
+
+		// 다음 페이지에 1개가존재해야한다
+		Assertions.assertEquals(1, nextResult.queryResults().size());
+
+		// 다음 페이지는 없다
+		Assertions.assertTrue(nextResult.possibleNextPageNumbers().isEmpty());
+	}
+}


### PR DESCRIPTION
## 📝 작업 내용
- 쿼리 DSL을 통한 동적 쿼리 구성
- 페이지 및 페이지 사이즈 정책적 제한 
  - ( 100만개 데이터 기준, 페이징 조회 offset = 약 20000개 이상부터 인덱스를 사용하지 않는 현상 )