### PR TITLE
hotfix: 20_000개 이상의 offset으로 조회되는 오류 수정

### DIFF
--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemQueryService.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemQueryService.java
@@ -25,7 +25,7 @@ public class SingleProblemQueryService {
 	public SingleProblemReadModelPageResult queryPage(
 		@NotNull @Valid final SingleProblemReadModelQuery query,
 		@NotNull @Range(min = 1, max = 20) final Integer pageSize,
-		@NotNull @Range(max = 999) final Integer pageNumber // 1000 - 1 ( 1 페이지는 오프셋 0임으로 )
+		@NotNull @Range(max = 1000) final Integer pageNumber // 페이지 번호 (1부터 시작). 내부 offset 계산 시 사용됨: offset = (pageNumber - 1) * pageSize
 	) {
 		final List<SingleProblemReadModel> readModels = singleProblemRepository.queryPage(query, pageSize, pageNumber);
 		final Long count = singleProblemRepository.count(query);

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemQueryService.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemQueryService.java
@@ -24,8 +24,8 @@ public class SingleProblemQueryService {
 
 	public SingleProblemReadModelPageResult queryPage(
 		@NotNull @Valid final SingleProblemReadModelQuery query,
-		@NotNull @Range(min = 1, max = 100) final Integer pageSize,
-		@NotNull @Range(max = 2000) final Integer pageNumber
+		@NotNull @Range(min = 1, max = 20) final Integer pageSize,
+		@NotNull @Range(max = 999) final Integer pageNumber // 1000 - 1 ( 1 페이지는 오프셋 0임으로 )
 	) {
 		final List<SingleProblemReadModel> readModels = singleProblemRepository.queryPage(query, pageSize, pageNumber);
 		final Long count = singleProblemRepository.count(query);

--- a/domain/mathrank-problem-single-read-domain/src/test/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemQueryServiceTest.java
+++ b/domain/mathrank-problem-single-read-domain/src/test/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemQueryServiceTest.java
@@ -15,6 +15,7 @@ import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+import jakarta.validation.ConstraintViolationException;
 import kr.co.mathrank.domain.problem.core.Difficulty;
 import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemReadModelPageResult;
 import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemReadModelQuery;
@@ -48,6 +49,14 @@ class SingleProblemQueryServiceTest {
 		registry.add("spring.datasource.url", mysql::getJdbcUrl);
 		registry.add("spring.datasource.username", mysql::getUsername);
 		registry.add("spring.datasource.password", mysql::getPassword);
+	}
+
+	@Test
+	void 오프셋이_20_000초과로_조회할_수_없다() {
+		final SingleProblemReadModelQuery query = new SingleProblemReadModelQuery(null, "math", null, Difficulty.MID, Difficulty.MID, 10, 30, null, null);
+
+		// 20000이상임으로 불가
+		Assertions.assertThrows(ConstraintViolationException.class, () -> queryService.queryPage(query, 20, 1000));
 	}
 
 	@Test

--- a/domain/mathrank-problem-single-read-domain/src/test/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemQueryServiceTest.java
+++ b/domain/mathrank-problem-single-read-domain/src/test/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemQueryServiceTest.java
@@ -55,8 +55,8 @@ class SingleProblemQueryServiceTest {
 	void 오프셋이_20_000초과로_조회할_수_없다() {
 		final SingleProblemReadModelQuery query = new SingleProblemReadModelQuery(null, "math", null, Difficulty.MID, Difficulty.MID, 10, 30, null, null);
 
-		// 20000이상임으로 불가
-		Assertions.assertThrows(ConstraintViolationException.class, () -> queryService.queryPage(query, 20, 1000));
+		Assertions.assertThrows(ConstraintViolationException.class, () -> queryService.queryPage(query, 20, 1001));
+		Assertions.assertThrows(ConstraintViolationException.class, () -> queryService.queryPage(query, 21, 1000));
 	}
 
 	@Test


### PR DESCRIPTION
## 📝 작업 내용

20_000 개 이상 페이징 조회되는 오류를 수정했습니다. 

또한, 각 페이지의 최대 크기는 20으로 수정했습니다.