### PR TITLE
Single Problem Read Model Consumer 구현

### DIFF
--- a/app/consumer/mathrank-problem-single-consumer/build.gradle
+++ b/app/consumer/mathrank-problem-single-consumer/build.gradle
@@ -1,0 +1,10 @@
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'org.springframework.kafka:spring-kafka'
+
+    implementation project(':domain:mathrank-problem-single-read-domain')
+    implementation project(':domain:mathrank-problem-core-domain')
+    implementation project(':common:mathrank-event')
+
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
+}

--- a/app/consumer/mathrank-problem-single-consumer/src/main/java/kr/co/mathrank/SingleProblemReadModelConsumerApplication.java
+++ b/app/consumer/mathrank-problem-single-consumer/src/main/java/kr/co/mathrank/SingleProblemReadModelConsumerApplication.java
@@ -1,0 +1,11 @@
+package kr.co.mathrank;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class SingleProblemReadModelConsumerApplication {
+	public static void main(String[] args) {
+		SpringApplication.run(SingleProblemReadModelConsumerApplication.class);
+	}
+}

--- a/app/consumer/mathrank-problem-single-consumer/src/main/java/kr/co/mathrank/app/consumer/problem/single/ProblemUpdatedPayload.java
+++ b/app/consumer/mathrank-problem-single-consumer/src/main/java/kr/co/mathrank/app/consumer/problem/single/ProblemUpdatedPayload.java
@@ -1,0 +1,22 @@
+package kr.co.mathrank.app.consumer.problem.single;
+
+import java.time.LocalDateTime;
+
+import kr.co.mathrank.common.event.EventPayload;
+import kr.co.mathrank.domain.problem.core.AnswerType;
+import kr.co.mathrank.domain.problem.core.Difficulty;
+import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemReadModelUpdateCommand;
+
+public record ProblemUpdatedPayload(
+	Long problemId,
+	String coursePath,
+	String problemImage,
+	AnswerType answerType,
+	Difficulty difficulty,
+	LocalDateTime updatedAt
+) implements EventPayload {
+	public SingleProblemReadModelUpdateCommand toCommand() {
+		return new SingleProblemReadModelUpdateCommand(problemId, coursePath, problemImage, answerType, difficulty,
+			updatedAt);
+	}
+}

--- a/app/consumer/mathrank-problem-single-consumer/src/main/java/kr/co/mathrank/app/consumer/problem/single/SingleProblemReadModelConsumerConfiguration.java
+++ b/app/consumer/mathrank-problem-single-consumer/src/main/java/kr/co/mathrank/app/consumer/problem/single/SingleProblemReadModelConsumerConfiguration.java
@@ -1,0 +1,23 @@
+package kr.co.mathrank.app.consumer.problem.single;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.util.backoff.FixedBackOff;
+
+@Configuration
+@EnableKafka
+public class SingleProblemReadModelConsumerConfiguration {
+	@Bean
+	public DefaultErrorHandler errorHandler(KafkaTemplate<String, String> template) {
+		// 일시적인 오류에 대비한 재시도 정책을 설정합니다. (예: 1초 간격, 최대 3번)
+		final FixedBackOff backOff = new FixedBackOff(1000L, 3L);
+
+		final DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(template); // {topic}.DLT
+
+		return new DefaultErrorHandler(recoverer, backOff);
+	}
+}

--- a/app/consumer/mathrank-problem-single-consumer/src/main/java/kr/co/mathrank/app/consumer/problem/single/SingleProblemReadModelUpdateMessageConsumer.java
+++ b/app/consumer/mathrank-problem-single-consumer/src/main/java/kr/co/mathrank/app/consumer/problem/single/SingleProblemReadModelUpdateMessageConsumer.java
@@ -10,6 +10,17 @@ import kr.co.mathrank.domain.problem.single.read.service.SingleProblemUpdateServ
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * 개별 문제 조회용 Read Model을 업데이트하는 Kafka 메시지 컨슈머입니다.
+ * <p>
+ * 이 컨슈머는 문제 정보(예: 내용, 난이도) 변경 이벤트와 문제 풀이 통계 변경 이벤트를 수신하여,
+ * CQRS 패턴의 조회(Query) 측 모델을 최신 상태로 유지하는 역할을 담당합니다.
+ *
+ * 메시지 포맷은 <a href="https://snow-quasar-645.notion.site/Message-Format-249631417ede80a6a7dade6a34c0420a?pvs=73">
+ * 이 문서</a>에 설명되어 있습니다.
+ *
+ * @see SingleProblemUpdateService
+ */
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -18,28 +29,37 @@ public class SingleProblemReadModelUpdateMessageConsumer {
 
 	static final String GROUP_ID = "single-problem-read-model-updaters";
 
+	// 문제 정보(내용, 이미지, 난이도 등) 변경 이벤트 토픽
 	static final String PROBLEM_INFO_UPDATED_TOPIC = "problem-info-updated";
+	// 문제 풀이 통계(제출 수, 정답 수) 변경 이벤트 토픽
 	static final String SINGLE_PROBLEM_STATISTICS_UPDATED_TOPIC = "single-problem-statistics-updated";
 
+	/**
+	 * 문제 정보 변경 이벤트를 수신하여 Read Model을 업데이트합니다.
+	 *
+	 * @param message Kafka로부터 수신한 JSON 형식의 이벤트 메시지
+	 */
 	@KafkaListener(
 		groupId = GROUP_ID,
 		topics = PROBLEM_INFO_UPDATED_TOPIC
 	)
 	public void consumeProblemInfoUpdatedMessage(final String message) {
-		log.debug("[SingleProblemReadModelConsumer.consumeProblemInfoUpdatedMessage] received message: {}", message);
 		final Event<ProblemUpdatedPayload> event = Event.fromJson(message, ProblemUpdatedPayload.class);
 		final SingleProblemReadModelUpdateCommand command = event.getPayload().toCommand();
 
 		singleProblemUpdateService.updateProblemInfo(command);
 	}
 
+	/**
+	 * 문제 풀이 통계 변경 이벤트를 수신하여 Read Model을 업데이트합니다.
+	 *
+	 * @param message Kafka로부터 수신한 JSON 형식의 이벤트 메시지
+	 */
 	@KafkaListener(
 		groupId = GROUP_ID,
 		topics = SINGLE_PROBLEM_STATISTICS_UPDATED_TOPIC
 	)
 	public void consumeSingleProblemStatisticsUpdatedMessage(final String message) {
-		log.debug("[SingleProblemReadModelConsumer.consumeSingleProblemStatisticsUpdatedMessage] received message: {}",
-			message);
 		final Event<SingleProblemStatisticsUpdatedPayload> event = Event.fromJson(message,
 			SingleProblemStatisticsUpdatedPayload.class);
 		final SingleProblemAttemptStatsUpdateCommand command = event.getPayload().toCommand();

--- a/app/consumer/mathrank-problem-single-consumer/src/main/java/kr/co/mathrank/app/consumer/problem/single/SingleProblemReadModelUpdateMessageConsumer.java
+++ b/app/consumer/mathrank-problem-single-consumer/src/main/java/kr/co/mathrank/app/consumer/problem/single/SingleProblemReadModelUpdateMessageConsumer.java
@@ -1,0 +1,32 @@
+package kr.co.mathrank.app.consumer.problem.single;
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import kr.co.mathrank.common.event.Event;
+import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemReadModelUpdateCommand;
+import kr.co.mathrank.domain.problem.single.read.service.SingleProblemUpdateService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SingleProblemReadModelUpdateMessageConsumer {
+	private final SingleProblemUpdateService singleProblemUpdateService;
+
+	static final String GROUP_ID = "single-problem-read-model-updaters";
+	static final String PROBLEM_INFO_UPDATED_TOPIC = "problem-info-updated";
+
+	@KafkaListener(
+		groupId = GROUP_ID,
+		topics = PROBLEM_INFO_UPDATED_TOPIC
+	)
+	public void consumeProblemInfoUpdatedMessage(final String message) {
+		log.debug("[SingleProblemReadModelConsumer.consumeProblemInfoUpdatedMessage] received message: {}", message);
+		final Event<ProblemUpdatedPayload> event = Event.fromJson(message, ProblemUpdatedPayload.class);
+		final SingleProblemReadModelUpdateCommand command = event.getPayload().toCommand();
+
+		singleProblemUpdateService.updateProblemInfo(command);
+	}
+}

--- a/app/consumer/mathrank-problem-single-consumer/src/main/java/kr/co/mathrank/app/consumer/problem/single/SingleProblemReadModelUpdateMessageConsumer.java
+++ b/app/consumer/mathrank-problem-single-consumer/src/main/java/kr/co/mathrank/app/consumer/problem/single/SingleProblemReadModelUpdateMessageConsumer.java
@@ -4,6 +4,7 @@ import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 
 import kr.co.mathrank.common.event.Event;
+import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemAttemptStatsUpdateCommand;
 import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemReadModelUpdateCommand;
 import kr.co.mathrank.domain.problem.single.read.service.SingleProblemUpdateService;
 import lombok.RequiredArgsConstructor;
@@ -16,7 +17,9 @@ public class SingleProblemReadModelUpdateMessageConsumer {
 	private final SingleProblemUpdateService singleProblemUpdateService;
 
 	static final String GROUP_ID = "single-problem-read-model-updaters";
+
 	static final String PROBLEM_INFO_UPDATED_TOPIC = "problem-info-updated";
+	static final String SINGLE_PROBLEM_STATISTICS_UPDATED_TOPIC = "single-problem-statistics-updated";
 
 	@KafkaListener(
 		groupId = GROUP_ID,
@@ -28,5 +31,19 @@ public class SingleProblemReadModelUpdateMessageConsumer {
 		final SingleProblemReadModelUpdateCommand command = event.getPayload().toCommand();
 
 		singleProblemUpdateService.updateProblemInfo(command);
+	}
+
+	@KafkaListener(
+		groupId = GROUP_ID,
+		topics = SINGLE_PROBLEM_STATISTICS_UPDATED_TOPIC
+	)
+	public void consumeSingleProblemStatisticsUpdatedMessage(final String message) {
+		log.debug("[SingleProblemReadModelConsumer.consumeSingleProblemStatisticsUpdatedMessage] received message: {}",
+			message);
+		final Event<SingleProblemStatisticsUpdatedPayload> event = Event.fromJson(message,
+			SingleProblemStatisticsUpdatedPayload.class);
+		final SingleProblemAttemptStatsUpdateCommand command = event.getPayload().toCommand();
+
+		singleProblemUpdateService.updateAttemptStatistics(command);
 	}
 }

--- a/app/consumer/mathrank-problem-single-consumer/src/main/java/kr/co/mathrank/app/consumer/problem/single/SingleProblemStatisticsUpdatedPayload.java
+++ b/app/consumer/mathrank-problem-single-consumer/src/main/java/kr/co/mathrank/app/consumer/problem/single/SingleProblemStatisticsUpdatedPayload.java
@@ -1,0 +1,20 @@
+package kr.co.mathrank.app.consumer.problem.single;
+
+import kr.co.mathrank.common.event.EventPayload;
+import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemAttemptStatsUpdateCommand;
+
+public record SingleProblemStatisticsUpdatedPayload(
+	Long singleProblemId,
+	Long firstTrySuccessCount,
+	Long totalAttemptedCount,
+	Long attemptedUserDistinctCount
+) implements EventPayload {
+	public SingleProblemAttemptStatsUpdateCommand toCommand() {
+		return new SingleProblemAttemptStatsUpdateCommand(
+			this.singleProblemId,
+			this.firstTrySuccessCount,
+			this.totalAttemptedCount,
+			this.attemptedUserDistinctCount
+		);
+	}
+}

--- a/app/consumer/mathrank-problem-single-consumer/src/test/java/kr/co/mathrank/app/consumer/problem/single/SingleProblemReadModelConsumerTest.java
+++ b/app/consumer/mathrank-problem-single-consumer/src/test/java/kr/co/mathrank/app/consumer/problem/single/SingleProblemReadModelConsumerTest.java
@@ -22,6 +22,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import kr.co.mathrank.common.event.Event;
 import kr.co.mathrank.domain.problem.core.AnswerType;
 import kr.co.mathrank.domain.problem.core.Difficulty;
+import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemAttemptStatsUpdateCommand;
 import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemReadModelUpdateCommand;
 import kr.co.mathrank.domain.problem.single.read.service.SingleProblemUpdateService;
 
@@ -99,5 +100,55 @@ class SingleProblemReadModelConsumerTest {
 
 		// 서비스의 어떤 메소드도 호출되지 않았음을 검증합니다.
 		verifyNoInteractions(singleProblemUpdateService);
+	}
+
+	@Test
+	@DisplayName("유효한 통계 업데이트 이벤트를 수신하면, 서비스 로직을 호출한다")
+	void whenGivenValidEvent_thenCallsService() {
+		// given
+		final long singleProblemId = 123L;
+		final long firstTrySuccessCount = 1L;
+		final long attemptedUserDistinctCount = 2L;
+		final long totalAttemptedCount = 3L;
+		final var payload = new SingleProblemStatisticsUpdatedPayload(singleProblemId, firstTrySuccessCount,
+			totalAttemptedCount, attemptedUserDistinctCount);
+		final Event<SingleProblemStatisticsUpdatedPayload> event = Event.of(1L, payload);
+		final String message = event.serialize();
+
+		// when
+		kafkaTemplate.send(SingleProblemReadModelUpdateMessageConsumer.SINGLE_PROBLEM_STATISTICS_UPDATED_TOPIC,
+			message);
+
+		// then
+		final ArgumentCaptor<SingleProblemAttemptStatsUpdateCommand> commandCaptor =
+			ArgumentCaptor.forClass(SingleProblemAttemptStatsUpdateCommand.class);
+
+		// Awaitility를 사용하여 최대 5초 동안 서비스가 호출될 때까지 기다립니다.
+		await().atMost(5, TimeUnit.SECONDS)
+			.untilAsserted(() ->
+				verify(singleProblemUpdateService, times(1)).updateAttemptStatistics(commandCaptor.capture())
+			);
+
+		// 서비스에 전달된 Command 객체의 내용이 페이로드와 일치하는지 확인합니다.
+		final SingleProblemAttemptStatsUpdateCommand capturedCommand = commandCaptor.getValue();
+		assertThat(capturedCommand.singleProblemId()).isEqualTo(singleProblemId);
+		assertThat(capturedCommand.firstTrySuccessCount()).isEqualTo(firstTrySuccessCount);
+		assertThat(capturedCommand.attemptedUserDistinctCount()).isEqualTo(attemptedUserDistinctCount);
+		assertThat(capturedCommand.totalAttemptedCount()).isEqualTo(totalAttemptedCount);
+	}
+
+	@Test
+	@DisplayName("유효하지 않은 형식의 메시지를 수신하면, 서비스 로직을 호출하지 않는다")
+	void whenGivenInvalidEvent_thenDoesNotCallService() {
+		// given
+		final String invalidMessage = "this is not a valid json";
+
+		// when
+		kafkaTemplate.send(SingleProblemReadModelUpdateMessageConsumer.SINGLE_PROBLEM_STATISTICS_UPDATED_TOPIC,
+			invalidMessage);
+
+		// then
+		// Mockito의 after()를 사용하여 1초 동안 기다린 후에도 서비스가 호출되지 않았음을 검증합니다.
+		verify(singleProblemUpdateService, after(1000).never()).updateAttemptStatistics(any());
 	}
 }

--- a/app/consumer/mathrank-problem-single-consumer/src/test/java/kr/co/mathrank/app/consumer/problem/single/SingleProblemReadModelConsumerTest.java
+++ b/app/consumer/mathrank-problem-single-consumer/src/test/java/kr/co/mathrank/app/consumer/problem/single/SingleProblemReadModelConsumerTest.java
@@ -1,0 +1,103 @@
+package kr.co.mathrank.app.consumer.problem.single;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.awaitility.Awaitility.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import kr.co.mathrank.common.event.Event;
+import kr.co.mathrank.domain.problem.core.AnswerType;
+import kr.co.mathrank.domain.problem.core.Difficulty;
+import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemReadModelUpdateCommand;
+import kr.co.mathrank.domain.problem.single.read.service.SingleProblemUpdateService;
+
+@SpringBootTest(classes = {
+	SingleProblemReadModelUpdateMessageConsumer.class,
+	SingleProblemReadModelConsumerConfiguration.class,
+	KafkaAutoConfiguration.class})
+@TestPropertySource(
+	properties = "spring.kafka.consumer.auto-offset-reset=earliest" // 리밸런싱 후, 토픽의 첫 오프셋 부터 읽도록 설정
+)
+@EmbeddedKafka(
+	topics = SingleProblemReadModelUpdateMessageConsumer.PROBLEM_INFO_UPDATED_TOPIC
+)
+// 테스트 간 컨텍스트를 초기화하여 테스트 격리 수준을 높입니다.
+@DirtiesContext
+@DisplayName("SingleProblemReadModelConsumer 통합 테스트")
+class SingleProblemReadModelConsumerTest {
+	@Autowired
+	private KafkaTemplate<String, String> kafkaTemplate;
+
+	// 실제 서비스 대신 Mock 객체를 주입하여 상호작용을 검증합니다.
+	@MockitoBean
+	private SingleProblemUpdateService singleProblemUpdateService;
+
+	@Test
+	void 유효한_업데이트_이벤트를_수신하면_페이로드를_파싱하여_서비스_로직을_호출한다() {
+		// given
+		// 테스트용 페이로드와 이벤트를 생성합니다.
+		final var payload = new ProblemUpdatedPayload(
+			101L,
+			"수학I > 지수함수와 로그함수",
+			"problem.png",
+			AnswerType.MULTIPLE_CHOICE,
+			Difficulty.LOW,
+			LocalDateTime.now()
+		);
+		final Event<ProblemUpdatedPayload> event = Event.of(1L, payload);
+		final String message = event.serialize();
+
+		// when
+		// 생성한 메시지를 Kafka 토픽으로 전송합니다.
+		kafkaTemplate.send(SingleProblemReadModelUpdateMessageConsumer.PROBLEM_INFO_UPDATED_TOPIC, message);
+
+		// then
+		// 비동기 처리를 기다린 후, 서비스가 올바르게 호출되었는지 검증합니다.
+		final ArgumentCaptor<SingleProblemReadModelUpdateCommand> commandCaptor =
+			ArgumentCaptor.forClass(SingleProblemReadModelUpdateCommand.class);
+
+		// Awaitility를 사용하여 최대 5초 동안 100ms 간격으로 singleProblemUpdateService.updateProblemInfo가 1번 호출될 때까지 기다립니다.
+		await().atMost(5, TimeUnit.SECONDS).pollInterval(100, TimeUnit.MILLISECONDS)
+			.untilAsserted(() -> verify(singleProblemUpdateService, times(1)).updateProblemInfo(commandCaptor.capture())
+			);
+
+		// 서비스에 전달된 Command 객체의 내용이 페이로드와 일치하는지 확인합니다.
+		final SingleProblemReadModelUpdateCommand capturedCommand = commandCaptor.getValue();
+		assertThat(capturedCommand.problemId()).isEqualTo(payload.problemId());
+		assertThat(capturedCommand.coursePath()).isEqualTo(payload.coursePath());
+		assertThat(capturedCommand.problemImage()).isEqualTo(payload.problemImage());
+		assertThat(capturedCommand.answerType()).isEqualTo(payload.answerType());
+		assertThat(capturedCommand.difficulty()).isEqualTo(payload.difficulty());
+	}
+
+	@Test
+	@DisplayName("유효하지 않은 형식의 메시지를 수신하면, 서비스 로직을 호출하지 않는다")
+	void 유효하지_않은_형식의_메시지를_수신하면_서비스_로직을_호출하지_않는다() throws InterruptedException {
+		// given
+		final String invalidMessage = "{\"key\":\"this is not a valid event format\"}";
+
+		// when
+		kafkaTemplate.send(SingleProblemReadModelUpdateMessageConsumer.PROBLEM_INFO_UPDATED_TOPIC, invalidMessage);
+
+		// then
+		// 메시지 처리 및 에러 핸들링에 시간이 걸릴 수 있으므로 잠시 대기합니다.
+		Thread.sleep(1000);
+
+		// 서비스의 어떤 메소드도 호출되지 않았음을 검증합니다.
+		verifyNoInteractions(singleProblemUpdateService);
+	}
+}

--- a/domain/mathrank-problem-single-read-domain/build.gradle
+++ b/domain/mathrank-problem-single-read-domain/build.gradle
@@ -19,6 +19,7 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+    runtimeOnly 'com.h2database:h2'
 }
 
 def querydslSrcDir = 'src/main/generated'

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,6 +18,7 @@ include(
         'app:api:mathrank-school-read-api',
         'app:batch',
         'app:consumer',
+        'app:consumer:mathrank-problem-single-consumer',
 
         'client',
         'client:internal',


### PR DESCRIPTION
## 📝 작업 내용

- `Consumer`로 메세지를 수신해 `SingleProblemReadModel` 을 업데이트
  - `문제 풀이 총 시도 수`, `첫 시도 성공 수`, `시도한 사용자 수` 등의 통계 정보  업데이트
  - `문제`의 변경 사항 업데이트