### PR TITLE
feat(problem-single-read): 개별 문제 페이징 조회 api 구성

### DIFF
--- a/app/api/mathrank-problem-single-read-api/build.gradle
+++ b/app/api/mathrank-problem-single-read-api/build.gradle
@@ -1,0 +1,10 @@
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
+    implementation project(':domain:mathrank-problem-single-read-domain')
+    implementation project(':domain:mathrank-problem-core-domain')
+
+    implementation project(':app:api:mathrank-api-common')
+}

--- a/app/api/mathrank-problem-single-read-api/src/main/java/kr/co/mathrank/app/api/problem/single/read/SingleProblemQueryRequest.java
+++ b/app/api/mathrank-problem-single-read-api/src/main/java/kr/co/mathrank/app/api/problem/single/read/SingleProblemQueryRequest.java
@@ -1,0 +1,35 @@
+package kr.co.mathrank.app.api.problem.single.read;
+
+import kr.co.mathrank.domain.problem.core.AnswerType;
+import kr.co.mathrank.domain.problem.core.Difficulty;
+import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemReadModelQuery;
+
+public record SingleProblemQueryRequest(
+	Long singleProblemId,
+
+	String coursePath,
+
+	AnswerType answerType,
+
+	Difficulty difficultyMinInclude,
+	Difficulty difficultyMaxInclude,
+
+	Integer accuracyMinInclude,
+	Integer accuracyMaxInclude,
+
+	Long totalAttemptCountMinInclude,
+	Long totalAttemptCountMaxInclude
+) {
+	public SingleProblemReadModelQuery toQuery() {
+		return new SingleProblemReadModelQuery(
+			singleProblemId,
+			coursePath,
+			answerType,
+			difficultyMinInclude,
+			difficultyMaxInclude,
+			accuracyMinInclude,
+			accuracyMaxInclude,
+			totalAttemptCountMinInclude,
+			totalAttemptCountMaxInclude);
+	}
+}

--- a/app/api/mathrank-problem-single-read-api/src/main/java/kr/co/mathrank/app/api/problem/single/read/SingleProblemReadController.java
+++ b/app/api/mathrank-problem-single-read-api/src/main/java/kr/co/mathrank/app/api/problem/single/read/SingleProblemReadController.java
@@ -27,8 +27,8 @@ public class SingleProblemReadController {
 	@Authorization(openedForAll = true)
 	public ResponseEntity<SingleProblemReadModelPageResult> getSingleProblems(
 		@ModelAttribute @ParameterObject final SingleProblemQueryRequest query,
-		@Range(min = 1, max = 1000) @RequestParam final Integer pageNumber,
-		@Range(min = 1, max = 20) @RequestParam final Integer pageSize
+		@Range(min = 1, max = 1000) @RequestParam(defaultValue = "1") final Integer pageNumber,
+		@Range(min = 1, max = 20) @RequestParam(defaultValue = "1") final Integer pageSize
 	) {
 		final SingleProblemReadModelPageResult result = singleProblemQueryService.queryPage(query.toQuery(), pageSize,
 			pageNumber);

--- a/app/api/mathrank-problem-single-read-api/src/main/java/kr/co/mathrank/app/api/problem/single/read/SingleProblemReadController.java
+++ b/app/api/mathrank-problem-single-read-api/src/main/java/kr/co/mathrank/app/api/problem/single/read/SingleProblemReadController.java
@@ -27,7 +27,7 @@ public class SingleProblemReadController {
 	@Authorization(openedForAll = true)
 	public ResponseEntity<SingleProblemReadModelPageResult> getSingleProblems(
 		@ModelAttribute @ParameterObject final SingleProblemQueryRequest query,
-		@Range(min = 1, max = 20) @Range@RequestParam("pageNumber") final Integer pageNumber,
+		@Range(min = 1, max = 20) @RequestParam("pageNumber") final Integer pageNumber,
 		@Max(1000) @RequestParam("pageSize") final Integer pageSize
 	) {
 		final SingleProblemReadModelPageResult result = singleProblemQueryService.queryPage(query.toQuery(), pageSize,

--- a/app/api/mathrank-problem-single-read-api/src/main/java/kr/co/mathrank/app/api/problem/single/read/SingleProblemReadController.java
+++ b/app/api/mathrank-problem-single-read-api/src/main/java/kr/co/mathrank/app/api/problem/single/read/SingleProblemReadController.java
@@ -1,0 +1,37 @@
+package kr.co.mathrank.app.api.problem.single.read;
+
+import org.hibernate.validator.constraints.Range;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import kr.co.mathrank.app.api.common.authentication.Authorization;
+import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemReadModelPageResult;
+import kr.co.mathrank.domain.problem.single.read.service.SingleProblemQueryService;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "개별 문제 API")
+@RestController
+@RequiredArgsConstructor
+public class SingleProblemReadController {
+	private final SingleProblemQueryService singleProblemQueryService;
+
+	@GetMapping("/api/v1/problem/single")
+	@Operation(summary = "풀이 시도 가능한 개별문제 페이징 조회 API")
+	@Authorization(openedForAll = true)
+	public ResponseEntity<SingleProblemReadModelPageResult> getSingleProblems(
+		@ModelAttribute @ParameterObject final SingleProblemQueryRequest query,
+		@Range(min = 1, max = 20) @Range@RequestParam("pageNumber") final Integer pageNumber,
+		@Max(1000) @RequestParam("pageSize") final Integer pageSize
+	) {
+		final SingleProblemReadModelPageResult result = singleProblemQueryService.queryPage(query.toQuery(), pageSize,
+			pageNumber);
+		return ResponseEntity.ok(result);
+	}
+}

--- a/app/api/mathrank-problem-single-read-api/src/main/java/kr/co/mathrank/app/api/problem/single/read/SingleProblemReadController.java
+++ b/app/api/mathrank-problem-single-read-api/src/main/java/kr/co/mathrank/app/api/problem/single/read/SingleProblemReadController.java
@@ -27,8 +27,8 @@ public class SingleProblemReadController {
 	@Authorization(openedForAll = true)
 	public ResponseEntity<SingleProblemReadModelPageResult> getSingleProblems(
 		@ModelAttribute @ParameterObject final SingleProblemQueryRequest query,
-		@Range(min = 1, max = 20) @RequestParam("pageNumber") final Integer pageNumber,
-		@Max(1000) @RequestParam("pageSize") final Integer pageSize
+		@Range(min = 1, max = 1000) @RequestParam final Integer pageNumber,
+		@Range(min = 1, max = 20) @RequestParam final Integer pageSize
 	) {
 		final SingleProblemReadModelPageResult result = singleProblemQueryService.queryPage(query.toQuery(), pageSize,
 			pageNumber);

--- a/app/api/monolith-api/build.gradle
+++ b/app/api/monolith-api/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     implementation project(':app:api:mathrank-problem-inner-api')
     implementation project(':app:api:mathrank-school-read-api')
     implementation project(':app:api:mathrank-problem-single-api')
+    implementation project(':app:api:mathrank-problem-single-read-api')
 
     implementation project(':app:init:mathrank-problem-init')
     implementation project(':app:init:mathrank-auth-init')

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,6 +7,7 @@ include(
         'app:init:mathrank-problem-init',
         'app:api',
         'app:api:mathrank-problem-single-api',
+        'app:api:mathrank-problem-single-read-api',
         'app:api:mathrank-healthcheck-api',
         'app:api:monolith-api',
         'app:api:mathrank-image-api',


### PR DESCRIPTION
## 📝 작업 내용

- `Single Problem` 페이징 api 구성
- swagger 문서 
- 모놀리식 빌드 모듈에 의존성 추가
- 도메인 모듈의 `Constraint` 그대로 적용
  - 제약이 `Controller`, `Service`에서 중복되어 적용됨 -> 유지 보수성에 영향을 끼친다고 판단, 
  - 이후 `Composite Validation` 으로의 리팩토링 필요할 수 있다 인지. 