### PR TITLE
hotfix: 단일 문제 조회 api 가 다른 api와 곂치는 부분 수정

### DIFF
--- a/app/api/mathrank-problem-read-api/src/main/java/kr/co/mathrank/app/api/problem/read/ProblemReadController.java
+++ b/app/api/mathrank-problem-read-api/src/main/java/kr/co/mathrank/app/api/problem/read/ProblemReadController.java
@@ -6,6 +6,7 @@ import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -54,9 +55,9 @@ public class ProblemReadController {
 	}
 
 	@Operation(summary = "문제 단일 조회 API")
-	@GetMapping(value = "/api/v1/problem/single")
+	@GetMapping(value = "/api/v1/problem/{problemId}")
 	public ResponseEntity<ProblemResponse> getProblem(
-		@RequestParam final Long problemId
+		@PathVariable final Long problemId
 	) {
 		final ProblemQueryResult result = problemQueryService.getSingle(problemId);
 		final ProblemResponse response = toResponse(result);


### PR DESCRIPTION
## 📝 작업 내용

`SingleProblem`의 api 와 `Problem`의 api 경로가 곂치는 문제 존재. 

## 해결방안

`Problem` 도메인의 경로 수정 