### PR TITLE
주소 기반으로 학교목록 조회 API 구성

### DIFF
--- a/app/api/mathrank-school-read-api/src/main/java/kr/co/mathrank/app/api/school/SchoolQueryController.java
+++ b/app/api/mathrank-school-read-api/src/main/java/kr/co/mathrank/app/api/school/SchoolQueryController.java
@@ -54,6 +54,7 @@ public class SchoolQueryController {
 	) {
 		return ResponseEntity.ok(schoolClient.getSchoolsByCityName(RequestType.JSON.getType(), cityName).getSchoolInfo()
 			.stream()
+			.filter(schoolInfo -> schoolInfo.ORG_RDNMA() != null)
 			.filter(schoolInfo -> schoolInfo.ORG_RDNMA().contains(district))
 			.map(SchoolResponse::from)
 			.toList());

--- a/app/api/mathrank-school-read-api/src/main/java/kr/co/mathrank/app/api/school/SchoolQueryController.java
+++ b/app/api/mathrank-school-read-api/src/main/java/kr/co/mathrank/app/api/school/SchoolQueryController.java
@@ -23,6 +23,10 @@ import lombok.extern.slf4j.Slf4j;
 public class SchoolQueryController {
 	private final SchoolClient schoolClient;
 
+	// 단일 "구"로 필터링 하기 위한 포맷
+	// " 서구 "
+	private static final String DISTRICT_FORMAT = " %s ";
+
 	@Operation(summary = "학교의 이름을 통한 조회 API", description = "schoolName 을 입력하지 않을 시, 빈값으로 사용됩니다.")
 	@GetMapping("/api/v1/schools")
 	public ResponseEntity<List<SchoolResponse>> loadInfos(
@@ -52,10 +56,15 @@ public class SchoolQueryController {
 		@Parameter(description = "구 이름", example = "서구")
 		final String district
 	) {
+		// 단일 "구"로 필터링하기 위해 포맷함
+		// ex)
+		// 이전: "서구" 조회 시, "강서구"도 조회 결과에 포함됨
+		// 현재: "서구" 조회 시, "서구"만 조회됨
+		final String formattedDistrict = DISTRICT_FORMAT.formatted(district);
 		return ResponseEntity.ok(schoolClient.getSchoolsByCityName(RequestType.JSON.getType(), cityName).getSchoolInfo()
 			.stream()
 			.filter(schoolInfo -> schoolInfo.ORG_RDNMA() != null)
-			.filter(schoolInfo -> schoolInfo.ORG_RDNMA().contains(district))
+			.filter(schoolInfo -> schoolInfo.ORG_RDNMA().contains(formattedDistrict))
 			.map(SchoolResponse::from)
 			.toList());
 	}

--- a/app/api/mathrank-school-read-api/src/main/java/kr/co/mathrank/app/api/school/SchoolQueryController.java
+++ b/app/api/mathrank-school-read-api/src/main/java/kr/co/mathrank/app/api/school/SchoolQueryController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.co.mathrank.client.external.school.RequestType;
 import kr.co.mathrank.client.external.school.SchoolClient;
@@ -39,5 +40,22 @@ public class SchoolQueryController {
 				.getSchoolInfo().stream()
 				.map(SchoolResponse::from)
 				.toList());
+	}
+
+	@Operation(summary = "학교 위치 정보기반 학교 조회 API", description = "cityName에 주의해야합니다. 반드시 서울특별시, 부산광역시 와 같은 풀네임으로 검색해야 합니다. ex) 부산 (X), 서울 (X)")
+	@GetMapping("/api/v1/schools/by-address")
+	public ResponseEntity<List<SchoolResponse>> loadSchoolsByAddress(
+		@RequestParam
+		@Parameter(description = "도시이름", example = "서울특별시")
+		final String cityName,
+		@RequestParam
+		@Parameter(description = "구 이름", example = "서구")
+		final String district
+	) {
+		return ResponseEntity.ok(schoolClient.getSchoolsByCityName(RequestType.JSON.getType(), cityName).getSchoolInfo()
+			.stream()
+			.filter(schoolInfo -> schoolInfo.ORG_RDNMA().contains(district))
+			.map(SchoolResponse::from)
+			.toList());
 	}
 }

--- a/client/external/mathrank-school/src/main/java/kr/co/mathrank/client/external/school/SchoolClient.java
+++ b/client/external/mathrank-school/src/main/java/kr/co/mathrank/client/external/school/SchoolClient.java
@@ -47,4 +47,23 @@ public class SchoolClient {
 			.retrieve()
 			.body(SchoolResponse.class);
 	}
+
+	/**
+	 *
+	 * @param type
+	 * @param cityName ex) 부산광역시, 서울특별시, 인천광역시
+	 * @return
+	 */
+	public SchoolResponse getSchoolsByCityName(String type, String cityName) {
+		return restClient.get()
+			.uri(uriBuilder -> uriBuilder.path("/hub/schoolInfo")
+				.queryParam("Type", type)
+				.queryParam("pIndex", 1)
+				.queryParam("pSize", 1000)
+				.queryParam("KEY", key)
+				.queryParam("LCTN_SC_NM", cityName)
+				.build())
+			.retrieve()
+			.body(SchoolResponse.class);
+	}
 }

--- a/client/external/mathrank-school/src/test/java/kr/co/mathrank/client/external/school/SchoolClientTest.java
+++ b/client/external/mathrank-school/src/test/java/kr/co/mathrank/client/external/school/SchoolClientTest.java
@@ -39,4 +39,12 @@ class SchoolClientTest {
 		final Optional<SchoolInfo> info = schoolClient.getSchool(RequestType.JSON.getType(), "7150129123ㅇㅁㅈㅇㄴㅇ");
 		Assertions.assertTrue(info.isEmpty());
 	}
+
+	@Test
+	void 도시_이름으로_전체_조회하기() {
+		final SchoolResponse schoolResponse = schoolClient.getSchoolsByCityName(RequestType.JSON.getType(), "부산광역시");
+
+		// 테스트 환경에서 api 키 사용 안함으로 default 값인 5로만 획득
+		Assertions.assertEquals(5, schoolResponse.getSchoolInfo().size());
+	}
 }


### PR DESCRIPTION
## 📝 작업 내용
 API는 `시`와 `구`를 입력하면 해당 지역에 속한 학교 목록을 반환한다. 
- ex) 부산광역시 - 서구 로 해당 지역에 속한 학교 리스트 총합 조회
- 조사결과 `neiceAPI` 도시 기반 조회의 최대값이 약 1,000개임으로 페이지 사이즈를 1,000으로 설정했다. 
- 
### 내부 구현
- 구현은 NIECE API 특성에 따라
  - 1) 도시명 조회 
  - 2) 그 결과에서 구 정보를 기준으로 필터링하는 방식

### 주의 사항
- 테스트 환경에서는 `API Key`가 없어 기본 제공되는 5개 데이터만 나와 정상 동작하지 않는 것처럼 보일 수 있지만, 배포 환경에서는 정상적으로 동작을 확인했다.
- 캐싱은 현재 전략이 온전히 수립되지 않았음으로, 실 배포 전에 전반적으로 도입하도록 한다.
