### PR TITLE
시험지 등록 기능 구현 

### DIFF
--- a/domain/mathrank-problem-assessment-domain/build.gradle
+++ b/domain/mathrank-problem-assessment-domain/build.gradle
@@ -1,0 +1,5 @@
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    testRuntimeOnly 'com.h2database:h2'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+}

--- a/domain/mathrank-problem-assessment-domain/build.gradle
+++ b/domain/mathrank-problem-assessment-domain/build.gradle
@@ -1,5 +1,9 @@
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     testRuntimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
+
+    implementation project(':common:mathrank-role')
+    implementation project(':common:mathrank-exception')
 }

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/constraint/AssessmentDurationConstraint.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/constraint/AssessmentDurationConstraint.java
@@ -1,0 +1,21 @@
+package kr.co.mathrank.domain.problem.assessment.constraint;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+@Target({ ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = AssessmentDurationRangeValidator.class)
+public @interface AssessmentDurationConstraint {
+	String message() default "시험시간이 잘못 설정됐습니다.";
+	Class<?>[] groups() default {};
+	Class<? extends Payload>[] payload() default {};
+
+	long minIncludeMinutes();
+	long maxIncludeMinutes();
+}

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/constraint/AssessmentDurationRangeValidator.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/constraint/AssessmentDurationRangeValidator.java
@@ -1,0 +1,26 @@
+package kr.co.mathrank.domain.problem.assessment.constraint;
+
+import java.time.Duration;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class AssessmentDurationRangeValidator implements ConstraintValidator<AssessmentDurationConstraint, Duration> {
+	private long minIncludeMinutes;
+	private long maxIncludeMinutes;
+
+	@Override
+	public void initialize(AssessmentDurationConstraint assessmentDurationConstraint) {
+		this.minIncludeMinutes = assessmentDurationConstraint.minIncludeMinutes();
+		this.maxIncludeMinutes = assessmentDurationConstraint.maxIncludeMinutes();
+	}
+
+	@Override
+	public boolean isValid(Duration value, ConstraintValidatorContext context) {
+		if (value == null) {
+			return true; // @NotNull은 별도 처리
+		}
+		long millis = value.toMinutes();
+		return millis >= minIncludeMinutes && millis <= maxIncludeMinutes;
+	}
+}

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/constraint/AssessmentDurationRangeValidator.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/constraint/AssessmentDurationRangeValidator.java
@@ -20,7 +20,7 @@ public class AssessmentDurationRangeValidator implements ConstraintValidator<Ass
 		if (value == null) {
 			return true; // @NotNull은 별도 처리
 		}
-		long millis = value.toMinutes();
-		return millis >= minIncludeMinutes && millis <= maxIncludeMinutes;
+		long minutes = value.toMinutes();
+		return minutes >= minIncludeMinutes && minutes <= maxIncludeMinutes;
 	}
 }

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/dto/AssessmentRegisterCommand.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/dto/AssessmentRegisterCommand.java
@@ -1,0 +1,24 @@
+package kr.co.mathrank.domain.problem.assessment.dto;
+
+import java.util.List;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import kr.co.mathrank.common.role.Role;
+
+public record AssessmentRegisterCommand(
+	@NotNull
+	Long registerMemberId,
+
+	@NotNull
+	Role role,
+
+	@NotBlank
+	String assessmentName,
+
+	@NotNull
+	@Size(min = 1)
+	List<Long> problemIds
+) {
+}

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/dto/AssessmentRegisterCommand.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/dto/AssessmentRegisterCommand.java
@@ -1,11 +1,13 @@
 package kr.co.mathrank.domain.problem.assessment.dto;
 
+import java.time.Duration;
 import java.util.List;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import kr.co.mathrank.common.role.Role;
+import kr.co.mathrank.domain.problem.assessment.constraint.AssessmentDurationConstraint;
 
 public record AssessmentRegisterCommand(
 	@NotNull
@@ -19,6 +21,10 @@ public record AssessmentRegisterCommand(
 
 	@NotNull
 	@Size(min = 1)
-	List<Long> problemIds
+	List<Long> problemIds,
+
+	@NotNull
+	@AssessmentDurationConstraint(minIncludeMinutes = 1, maxIncludeMinutes = 60 * 10)
+	Duration minutes // 시험 시간
 ) {
 }

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/entity/Assessment.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/entity/Assessment.java
@@ -1,0 +1,55 @@
+package kr.co.mathrank.domain.problem.assessment.entity;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hibernate.annotations.BatchSize;
+import org.hibernate.annotations.CreationTimestamp;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Assessment {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private Long registerMemberId;
+
+	private String assessmentName;
+
+	@OneToMany(mappedBy = "assessment", orphanRemoval = true, cascade = CascadeType.PERSIST)
+	private final List<AssessmentItem> assessmentItems = new ArrayList<>();
+
+	@CreationTimestamp
+	@Setter(AccessLevel.NONE)
+	private LocalDateTime createdAt;
+
+	public void setAssessmentItems(final List<Long> problemIds) {
+		this.assessmentItems.clear();
+		for (int i = 0; i < problemIds.size(); i++) {
+			assessmentItems.add(AssessmentItem.of(i + 1, problemIds.get(i), this));
+		}
+	}
+
+	public static Assessment of(final Long registerMemberId, final String assessmentName) {
+		final Assessment assessment = new Assessment();
+		assessment.setRegisterMemberId(registerMemberId);
+		assessment.setAssessmentName(assessmentName);
+
+		return assessment;
+	}
+}

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/entity/Assessment.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/entity/Assessment.java
@@ -1,5 +1,6 @@
 package kr.co.mathrank.domain.problem.assessment.entity;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -8,6 +9,7 @@ import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.CreationTimestamp;
 
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -31,6 +33,9 @@ public class Assessment {
 
 	private String assessmentName;
 
+	@Convert(converter = AssessmentDurationConverter.class)
+	private Duration assessmentDuration;
+
 	@OneToMany(mappedBy = "assessment", orphanRemoval = true, cascade = CascadeType.PERSIST)
 	private final List<AssessmentItem> assessmentItems = new ArrayList<>();
 
@@ -45,10 +50,11 @@ public class Assessment {
 		}
 	}
 
-	public static Assessment of(final Long registerMemberId, final String assessmentName) {
+	public static Assessment of(final Long registerMemberId, final String assessmentName, final Duration assessmentDuration) {
 		final Assessment assessment = new Assessment();
 		assessment.setRegisterMemberId(registerMemberId);
 		assessment.setAssessmentName(assessmentName);
+		assessment.setAssessmentDuration(assessmentDuration);
 
 		return assessment;
 	}

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/entity/Assessment.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/entity/Assessment.java
@@ -27,6 +27,7 @@ import lombok.Setter;
 public class Assessment {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Setter(AccessLevel.NONE)
 	private Long id;
 
 	private Long registerMemberId;
@@ -52,9 +53,9 @@ public class Assessment {
 
 	public static Assessment of(final Long registerMemberId, final String assessmentName, final Duration assessmentDuration) {
 		final Assessment assessment = new Assessment();
-		assessment.setRegisterMemberId(registerMemberId);
-		assessment.setAssessmentName(assessmentName);
-		assessment.setAssessmentDuration(assessmentDuration);
+		assessment.registerMemberId = registerMemberId;
+		assessment.assessmentName = assessmentName;
+		assessment.assessmentDuration = assessmentDuration;
 
 		return assessment;
 	}

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/entity/AssessmentDurationConverter.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/entity/AssessmentDurationConverter.java
@@ -10,11 +10,11 @@ import jakarta.persistence.Converter;
 public class AssessmentDurationConverter implements AttributeConverter<Duration, Time> {
 	@Override
 	public Time convertToDatabaseColumn(Duration attribute) {
-		return new Time(attribute.toMillis());
+		return attribute == null ? null : new Time(attribute.toMillis());
 	}
 
 	@Override
 	public Duration convertToEntityAttribute(Time dbData) {
-		return Duration.ofMillis(dbData.getTime());
+		return dbData == null ? null : Duration.ofMillis(dbData.getTime());
 	}
 }

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/entity/AssessmentDurationConverter.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/entity/AssessmentDurationConverter.java
@@ -10,11 +10,11 @@ import jakarta.persistence.Converter;
 public class AssessmentDurationConverter implements AttributeConverter<Duration, Time> {
 	@Override
 	public Time convertToDatabaseColumn(Duration attribute) {
-		return new Time(attribute.toMinutes());
+		return new Time(attribute.toMillis());
 	}
 
 	@Override
 	public Duration convertToEntityAttribute(Time dbData) {
-		return Duration.ofMinutes(dbData.getTime());
+		return Duration.ofMillis(dbData.getTime());
 	}
 }

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/entity/AssessmentDurationConverter.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/entity/AssessmentDurationConverter.java
@@ -1,0 +1,20 @@
+package kr.co.mathrank.domain.problem.assessment.entity;
+
+import java.sql.Time;
+import java.time.Duration;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter
+public class AssessmentDurationConverter implements AttributeConverter<Duration, Time> {
+	@Override
+	public Time convertToDatabaseColumn(Duration attribute) {
+		return new Time(attribute.toMinutes());
+	}
+
+	@Override
+	public Duration convertToEntityAttribute(Time dbData) {
+		return Duration.ofMinutes(dbData.getTime());
+	}
+}

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/entity/AssessmentItem.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/entity/AssessmentItem.java
@@ -17,6 +17,7 @@ import lombok.Setter;
 class AssessmentItem {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Setter(AccessLevel.NONE)
 	private Long id;
 
 	private Integer sequence;

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/entity/AssessmentItem.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/entity/AssessmentItem.java
@@ -29,9 +29,9 @@ class AssessmentItem {
 
 	public static AssessmentItem of(final Integer sequence, final Long problemId, final Assessment assessment) {
 		final AssessmentItem item = new AssessmentItem();
-		item.setSequence(sequence);
-		item.setProblemId(problemId);
-		item.setAssessment(assessment);
+		item.sequence = sequence;
+		item.problemId = problemId;
+		item.assessment = assessment;
 
 		return item;
 	}

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/entity/AssessmentItem.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/entity/AssessmentItem.java
@@ -1,0 +1,37 @@
+package kr.co.mathrank.domain.problem.assessment.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Setter
+class AssessmentItem {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private Integer sequence;
+
+	private Long problemId;
+
+	@ManyToOne
+	private Assessment assessment;
+
+	public static AssessmentItem of(final Integer sequence, final Long problemId, final Assessment assessment) {
+		final AssessmentItem item = new AssessmentItem();
+		item.setSequence(sequence);
+		item.setProblemId(problemId);
+		item.setAssessment(assessment);
+
+		return item;
+	}
+}

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/exception/AssessmentException.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/exception/AssessmentException.java
@@ -1,0 +1,9 @@
+package kr.co.mathrank.domain.problem.assessment.exception;
+
+import kr.co.mathrank.common.exception.MathRankException;
+
+public class AssessmentException extends MathRankException {
+	public AssessmentException(int code, String message) {
+		super(code, message);
+	}
+}

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/exception/AssessmentRegisterException.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/exception/AssessmentRegisterException.java
@@ -1,0 +1,9 @@
+package kr.co.mathrank.domain.problem.assessment.exception;
+
+import kr.co.mathrank.domain.problem.assessment.entity.Assessment;
+
+public class AssessmentRegisterException extends AssessmentException {
+	public AssessmentRegisterException() {
+		super(7001, "등록할 수 있는 권한 부재 (관리자만 등록 가능)");
+	}
+}

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/repository/AssessmentRepository.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/repository/AssessmentRepository.java
@@ -1,0 +1,8 @@
+package kr.co.mathrank.domain.problem.assessment.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kr.co.mathrank.domain.problem.assessment.entity.Assessment;
+
+public interface AssessmentRepository extends JpaRepository<Assessment, Long> {
+}

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/service/AssessmentRegisterService.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/service/AssessmentRegisterService.java
@@ -27,7 +27,7 @@ public class AssessmentRegisterService {
 			throw new AssessmentRegisterException();
 		}
 		// 관리자만 문제집 등록이 가능하다
-		final Assessment assessment = Assessment.of(command.registerMemberId(), command.assessmentName());
+		final Assessment assessment = Assessment.of(command.registerMemberId(), command.assessmentName(), command.minutes());
 		assessment.setAssessmentItems(command.problemIds());
 
 		assessmentRepository.save(assessment);

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/service/AssessmentRegisterService.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/service/AssessmentRegisterService.java
@@ -1,0 +1,37 @@
+package kr.co.mathrank.domain.problem.assessment.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.validation.annotation.Validated;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import kr.co.mathrank.common.role.Role;
+import kr.co.mathrank.domain.problem.assessment.dto.AssessmentRegisterCommand;
+import kr.co.mathrank.domain.problem.assessment.entity.Assessment;
+import kr.co.mathrank.domain.problem.assessment.exception.AssessmentRegisterException;
+import kr.co.mathrank.domain.problem.assessment.repository.AssessmentRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@Validated
+@RequiredArgsConstructor
+public class AssessmentRegisterService {
+	private final AssessmentRepository assessmentRepository;
+
+	public Long register(@NotNull @Valid final AssessmentRegisterCommand command) {
+		// 관리자가 아닐 경우 에러
+		if (!command.role().equals(Role.ADMIN)) {
+			log.warn("[AssessmentRegisterService.register] cannot register assessment - command: {}", command);
+			throw new AssessmentRegisterException();
+		}
+		// 관리자만 문제집 등록이 가능하다
+		final Assessment assessment = Assessment.of(command.registerMemberId(), command.assessmentName());
+		assessment.setAssessmentItems(command.problemIds());
+
+		assessmentRepository.save(assessment);
+		log.info("[AssessmentRegisterService.register] successfully registered assessment - assessmentId: {}, command: {}", assessment.getId(), command);
+		return assessment.getId();
+	}
+}

--- a/domain/mathrank-problem-assessment-domain/src/test/java/kr/co/mathrank/AssessmentDomainApplication.java
+++ b/domain/mathrank-problem-assessment-domain/src/test/java/kr/co/mathrank/AssessmentDomainApplication.java
@@ -1,0 +1,7 @@
+package kr.co.mathrank;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class AssessmentDomainApplication {
+}

--- a/domain/mathrank-problem-assessment-domain/src/test/java/kr/co/mathrank/domain/problem/assessment/entity/AssessmentDurationConverterTest.java
+++ b/domain/mathrank-problem-assessment-domain/src/test/java/kr/co/mathrank/domain/problem/assessment/entity/AssessmentDurationConverterTest.java
@@ -1,7 +1,5 @@
 package kr.co.mathrank.domain.problem.assessment.entity;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 import java.sql.Time;
 import java.time.Duration;
 
@@ -18,5 +16,15 @@ class AssessmentDurationConverterTest {
 
 		// 디비에 저장된 후 조회됐을떄, 같은값을 유지한다.
 		Assertions.assertEquals(tenMinute, converter.convertToEntityAttribute(time));
+	}
+
+	@Test
+	void 널값이_존재할땐_널로_변환한다() {
+		final AssessmentDurationConverter converter = new AssessmentDurationConverter();
+
+		Assertions.assertAll(
+			() -> Assertions.assertNull(converter.convertToEntityAttribute(null)),
+			() -> Assertions.assertNull(converter.convertToDatabaseColumn(null))
+		);
 	}
 }

--- a/domain/mathrank-problem-assessment-domain/src/test/java/kr/co/mathrank/domain/problem/assessment/entity/AssessmentDurationConverterTest.java
+++ b/domain/mathrank-problem-assessment-domain/src/test/java/kr/co/mathrank/domain/problem/assessment/entity/AssessmentDurationConverterTest.java
@@ -1,0 +1,22 @@
+package kr.co.mathrank.domain.problem.assessment.entity;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.sql.Time;
+import java.time.Duration;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class AssessmentDurationConverterTest {
+	@Test
+	void 디비에_저장된_후_조회됐을떄_같은값을_유지한다(){
+		final AssessmentDurationConverter converter = new AssessmentDurationConverter();
+
+		final Duration tenMinute = Duration.ofMinutes(10L);
+		final Time time = converter.convertToDatabaseColumn(tenMinute);
+
+		// 디비에 저장된 후 조회됐을떄, 같은값을 유지한다.
+		Assertions.assertEquals(tenMinute, converter.convertToEntityAttribute(time));
+	}
+}

--- a/domain/mathrank-problem-assessment-domain/src/test/java/kr/co/mathrank/domain/problem/assessment/entity/AssessmentTest.java
+++ b/domain/mathrank-problem-assessment-domain/src/test/java/kr/co/mathrank/domain/problem/assessment/entity/AssessmentTest.java
@@ -1,0 +1,99 @@
+package kr.co.mathrank.domain.problem.assessment.entity;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import kr.co.mathrank.domain.problem.assessment.repository.AssessmentRepository;
+
+@SpringBootTest(properties = """
+	spring.jpa.show-sql=true
+	spring.jpa.properties.hibernate.format_sql=true
+	""")
+class AssessmentTest {
+	@Autowired
+	private AssessmentRepository assessmentRepository;
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Test
+	void 시험지_생성시_문항들은_1번부터_순서대로_등록된다() {
+		final Assessment assessment = Assessment.of(1L, "test");
+		// 시험 문제 번호
+		assessment.setAssessmentItems(List.of(345L, 212L, 120232L, 1221323L));
+
+		Assertions.assertAll(
+			// 시험문제 갯수 확인
+			() -> Assertions.assertEquals(4, assessment.getAssessmentItems().size()),
+
+			// 문항 번호 확인
+			() -> Assertions.assertEquals(1, assessment.getAssessmentItems().get(0).getSequence()),
+			() -> Assertions.assertEquals(2, assessment.getAssessmentItems().get(1).getSequence()),
+			() -> Assertions.assertEquals(3, assessment.getAssessmentItems().get(2).getSequence()),
+			() -> Assertions.assertEquals(4, assessment.getAssessmentItems().get(3).getSequence())
+		);
+	}
+
+	@Test
+	void 시험지내_문제_수정은_전체를_바꿔야한다() {
+		final Assessment assessment = Assessment.of(1L, "test");
+		// 바꾸기 전 시험 문제 번호
+		assessment.setAssessmentItems(List.of(345L, 212L, 120232L, 1221323L));
+
+		// 새로운 문제들로 변경
+		assessment.setAssessmentItems(List.of(1212L, 2222L, 3333L));
+
+		Assertions.assertAll(
+			// 시험문제 갯수 확인
+			() -> Assertions.assertEquals(3, assessment.getAssessmentItems().size()),
+
+			// 문항 번호 확인
+			() -> Assertions.assertEquals(1, assessment.getAssessmentItems().get(0).getSequence()),
+			() -> Assertions.assertEquals(2, assessment.getAssessmentItems().get(1).getSequence()),
+			() -> Assertions.assertEquals(3, assessment.getAssessmentItems().get(2).getSequence())
+		);
+	}
+
+	@Test
+	@Transactional
+	void 트랜잭션_안에서_문항_변경시_DB_정상반영() {
+		final Assessment assessment = Assessment.of(1L, "test");
+		// 시험 문제 번호
+		assessment.setAssessmentItems(List.of(345L, 212L, 120232L, 1221323L));
+
+		// 새로운 엔티티DB 저장
+		assessmentRepository.save(assessment);
+		entityManager.flush();
+		entityManager.clear();
+
+		// 저장된 엔티티 가져와서 업데이트
+		final Long id = assessment.getId();
+		final Assessment reloadedAssessment = assessmentRepository.findById(id).orElseThrow();
+		reloadedAssessment.setAssessmentItems(List.of(1L, 2L, 3L));
+		entityManager.flush();
+		entityManager.clear();
+
+		// 저장된 값 확인
+		final Assessment last = assessmentRepository.findById(id).orElseThrow();
+		Assertions.assertAll(
+			() -> Assertions.assertEquals(3, last.getAssessmentItems().size()),
+
+			// 저장된 problemId 확인
+			() -> Assertions.assertIterableEquals(
+				List.of(1L, 2L, 3L),
+				last.getAssessmentItems().stream().map(AssessmentItem::getProblemId).toList()),
+
+			// 저장된 문제들의 순서 확인
+			() -> Assertions.assertIterableEquals(
+				List.of(1, 2, 3),
+				last.getAssessmentItems().stream().map(AssessmentItem::getSequence).toList()
+			)
+		);
+	}
+}

--- a/domain/mathrank-problem-assessment-domain/src/test/java/kr/co/mathrank/domain/problem/assessment/entity/AssessmentTest.java
+++ b/domain/mathrank-problem-assessment-domain/src/test/java/kr/co/mathrank/domain/problem/assessment/entity/AssessmentTest.java
@@ -1,5 +1,6 @@
 package kr.co.mathrank.domain.problem.assessment.entity;
 
+import java.time.Duration;
 import java.util.List;
 
 import org.junit.jupiter.api.Assertions;
@@ -24,7 +25,7 @@ class AssessmentTest {
 
 	@Test
 	void 시험지_생성시_문항들은_1번부터_순서대로_등록된다() {
-		final Assessment assessment = Assessment.of(1L, "test");
+		final Assessment assessment = Assessment.of(1L, "test", Duration.ofMinutes(100L));
 		// 시험 문제 번호
 		assessment.setAssessmentItems(List.of(345L, 212L, 120232L, 1221323L));
 
@@ -42,7 +43,7 @@ class AssessmentTest {
 
 	@Test
 	void 시험지내_문제_수정은_전체를_바꿔야한다() {
-		final Assessment assessment = Assessment.of(1L, "test");
+		final Assessment assessment = Assessment.of(1L, "test", Duration.ofMinutes(100L));
 		// 바꾸기 전 시험 문제 번호
 		assessment.setAssessmentItems(List.of(345L, 212L, 120232L, 1221323L));
 
@@ -63,7 +64,7 @@ class AssessmentTest {
 	@Test
 	@Transactional
 	void 트랜잭션_안에서_문항_변경시_DB_정상반영() {
-		final Assessment assessment = Assessment.of(1L, "test");
+		final Assessment assessment = Assessment.of(1L, "test", Duration.ofMinutes(100L));
 		// 시험 문제 번호
 		assessment.setAssessmentItems(List.of(345L, 212L, 120232L, 1221323L));
 

--- a/domain/mathrank-problem-assessment-domain/src/test/java/kr/co/mathrank/domain/problem/assessment/service/AssessmentRegisterServiceTest.java
+++ b/domain/mathrank-problem-assessment-domain/src/test/java/kr/co/mathrank/domain/problem/assessment/service/AssessmentRegisterServiceTest.java
@@ -1,5 +1,6 @@
 package kr.co.mathrank.domain.problem.assessment.service;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
@@ -38,7 +39,8 @@ class AssessmentRegisterServiceTest {
 			1L,
 			Role.ADMIN,
 			"새로운 수학 문제집",
-			List.of(101L, 102L, 103L)
+			List.of(101L, 102L, 103L),
+			Duration.ofMinutes(100)
 		);
 
 		// when & then
@@ -56,14 +58,15 @@ class AssessmentRegisterServiceTest {
 
 	private static Stream<Arguments> invalidAssessmentRegisterCommands() {
 		return Stream.of(
-			Arguments.of(new AssessmentRegisterCommand(null, Role.ADMIN, "유효한 이름", List.of(1L))),
+			Arguments.of(new AssessmentRegisterCommand(null, Role.ADMIN, "유효한 이름", List.of(1L), Duration.ofMinutes(100))),
 			// registerMemberId is null
-			Arguments.of(new AssessmentRegisterCommand(1L, null, "유효한 이름", List.of(1L))), // role is null
-			Arguments.of(new AssessmentRegisterCommand(1L, Role.ADMIN, null, List.of(1L))), // assessmentName is null
-			Arguments.of(new AssessmentRegisterCommand(1L, Role.ADMIN, "", List.of(1L))), // assessmentName is blank
-			Arguments.of(new AssessmentRegisterCommand(1L, Role.ADMIN, "  ", List.of(1L))), // assessmentName is blank
-			Arguments.of(new AssessmentRegisterCommand(1L, Role.ADMIN, "유효한 이름", null)), // problemIds is null
-			Arguments.of(new AssessmentRegisterCommand(1L, Role.ADMIN, "유효한 이름", Collections.emptyList()))
+			Arguments.of(new AssessmentRegisterCommand(1L, null, "유효한 이름", List.of(1L), Duration.ofMinutes(100))), // role is null
+			Arguments.of(new AssessmentRegisterCommand(1L, Role.ADMIN, null, List.of(1L), Duration.ofMinutes(100))), // assessmentName is null
+			Arguments.of(new AssessmentRegisterCommand(1L, Role.ADMIN, "", List.of(1L), Duration.ofMinutes(100))), // assessmentName is blank
+			Arguments.of(new AssessmentRegisterCommand(1L, Role.ADMIN, "  ", List.of(1L), Duration.ofMinutes(100))), // assessmentName is blank
+			Arguments.of(new AssessmentRegisterCommand(1L, Role.ADMIN, "유효한 이름", null, Duration.ofMinutes(100))), // problemIds is null
+			Arguments.of(new AssessmentRegisterCommand(1L, Role.ADMIN, "유효한 이름", Collections.emptyList(), Duration.ofMinutes(100))),
+			Arguments.of(new AssessmentRegisterCommand(1L, Role.ADMIN, "유효한 이름", List.of(1L), null))
 			// problemIds is empty
 		);
 	}

--- a/domain/mathrank-problem-assessment-domain/src/test/java/kr/co/mathrank/domain/problem/assessment/service/AssessmentRegisterServiceTest.java
+++ b/domain/mathrank-problem-assessment-domain/src/test/java/kr/co/mathrank/domain/problem/assessment/service/AssessmentRegisterServiceTest.java
@@ -17,11 +17,25 @@ import org.springframework.boot.test.context.SpringBootTest;
 import jakarta.validation.ConstraintViolationException;
 import kr.co.mathrank.common.role.Role;
 import kr.co.mathrank.domain.problem.assessment.dto.AssessmentRegisterCommand;
+import kr.co.mathrank.domain.problem.assessment.exception.AssessmentRegisterException;
 
 @SpringBootTest
 class AssessmentRegisterServiceTest {
 	@Autowired
 	private AssessmentRegisterService assessmentRegisterService;
+
+	@Test
+	void 관리자가_아니면_시험지_생성_불가능하다() {
+		Assertions.assertThrows(AssessmentRegisterException.class, () -> assessmentRegisterService.register(
+			new AssessmentRegisterCommand(
+				1L,
+				Role.USER,
+				"새로운 수학 문제집",
+				List.of(101L, 102L, 103L),
+				Duration.ofMinutes(100)
+			))
+		);
+	}
 
 	@DisplayName("register 메서드에 null을 전달하면 ConstraintViolationException이 발생한다.")
 	@Test

--- a/domain/mathrank-problem-assessment-domain/src/test/java/kr/co/mathrank/domain/problem/assessment/service/AssessmentRegisterServiceTest.java
+++ b/domain/mathrank-problem-assessment-domain/src/test/java/kr/co/mathrank/domain/problem/assessment/service/AssessmentRegisterServiceTest.java
@@ -1,0 +1,70 @@
+package kr.co.mathrank.domain.problem.assessment.service;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import jakarta.validation.ConstraintViolationException;
+import kr.co.mathrank.common.role.Role;
+import kr.co.mathrank.domain.problem.assessment.dto.AssessmentRegisterCommand;
+
+@SpringBootTest
+class AssessmentRegisterServiceTest {
+	@Autowired
+	private AssessmentRegisterService assessmentRegisterService;
+
+	@DisplayName("register 메서드에 null을 전달하면 ConstraintViolationException이 발생한다.")
+	@Test
+	void whenRegisterWithNullCommand_thenThrowsException() {
+		// when & then
+		Assertions.assertThrows(ConstraintViolationException.class,
+			() -> assessmentRegisterService.register(null));
+	}
+
+	@DisplayName("관리자(ADMIN) 권한으로 유효한 명령을 전달하면 성공적으로 등록된다.")
+	@Test
+	void whenRegisterWithValidCommandAsAdmin_thenSucceeds() {
+		// given
+		final AssessmentRegisterCommand validCommand = new AssessmentRegisterCommand(
+			1L,
+			Role.ADMIN,
+			"새로운 수학 문제집",
+			List.of(101L, 102L, 103L)
+		);
+
+		// when & then
+		Assertions.assertDoesNotThrow(() -> assessmentRegisterService.register(validCommand));
+	}
+
+	@DisplayName("유효하지 않은 AssessmentRegisterCommand로 등록을 시도하면 ConstraintViolationException이 발생한다.")
+	@ParameterizedTest
+	@MethodSource("invalidAssessmentRegisterCommands")
+	void whenRegisterWithInvalidCommand_thenThrowsException(final AssessmentRegisterCommand invalidCommand) {
+		// when & then
+		Assertions.assertThrows(ConstraintViolationException.class,
+			() -> assessmentRegisterService.register(invalidCommand));
+	}
+
+	private static Stream<Arguments> invalidAssessmentRegisterCommands() {
+		return Stream.of(
+			Arguments.of(new AssessmentRegisterCommand(null, Role.ADMIN, "유효한 이름", List.of(1L))),
+			// registerMemberId is null
+			Arguments.of(new AssessmentRegisterCommand(1L, null, "유효한 이름", List.of(1L))), // role is null
+			Arguments.of(new AssessmentRegisterCommand(1L, Role.ADMIN, null, List.of(1L))), // assessmentName is null
+			Arguments.of(new AssessmentRegisterCommand(1L, Role.ADMIN, "", List.of(1L))), // assessmentName is blank
+			Arguments.of(new AssessmentRegisterCommand(1L, Role.ADMIN, "  ", List.of(1L))), // assessmentName is blank
+			Arguments.of(new AssessmentRegisterCommand(1L, Role.ADMIN, "유효한 이름", null)), // problemIds is null
+			Arguments.of(new AssessmentRegisterCommand(1L, Role.ADMIN, "유효한 이름", Collections.emptyList()))
+			// problemIds is empty
+		);
+	}
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -30,6 +30,7 @@ include(
         'client:external:mathrank-school',
 
         'domain',
+        'domain:mathrank-problem-assessment-domain',
         'domain:mathrank-image-domain',
         'domain:mathrank-auth-domain',
         'domain:mathrank-problem-core-domain',


### PR DESCRIPTION
## 📝 작업 내용

문제집`Assessment`을 생성하고 관리하는 신규 도메인(mathrank-problem-assessment-domain)을 추가합니다. 
관리자는 여러 문제들을 묶어 하나의 문제집으로 등록하고, 시험 시간을 설정할 수 있습니다.

- `AssessmentRegisterService`를 구현하여 문제집 등록 로직을 담당합니다.
- 문제가 실제 존재하는지 확인하지 않습니다.
- 관리자(ADMIN)만 문제집을 등록할 수 있도록 권한 검증 로직을 포함했습니다.
- `@AssessmentDurationConstraint` 커스텀 제약 조건을 추가하여 시험 시간(1분 ~ 10시간)에 대한 비즈니스 규칙을 검증합니다.
- `AssessmentDurationConverter`를 통해 `Duration`타입 `MySQL` 매핑