### PR TITLE
feat(assessment): 시험지 답안지 등록 기능 구현

### DIFF
--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/entity/Assessment.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/entity/Assessment.java
@@ -39,6 +39,9 @@ public class Assessment {
 	@OneToMany(mappedBy = "assessment", orphanRemoval = true, cascade = CascadeType.PERSIST)
 	private final List<AssessmentItem> assessmentItems = new ArrayList<>();
 
+	@OneToMany(mappedBy = "assessment", orphanRemoval = true, cascade = CascadeType.PERSIST)
+	private final List<AssessmentSubmission> assessmentSubmissions = new ArrayList<>();
+
 	@CreationTimestamp
 	@Setter(AccessLevel.NONE)
 	private LocalDateTime createdAt;
@@ -50,6 +53,27 @@ public class Assessment {
 		assessment.assessmentDuration = assessmentDuration;
 
 		return assessment;
+	}
+
+	/**
+	 * 현재 시험에 대해 사용자의 응시 기록을 생성합니다.
+	 *
+	 * <p>시험에 속한 문항들을 시퀀스 오름차순으로 정렬한 뒤,
+	 * 사용자가 제출한 답안을 매칭하여 {@link AssessmentSubmission}에 추가합니다.</p>
+	 *
+	 * @param memberId 응시자 ID
+	 * @param answers 각 문항에 대한 답안 목록. {@code assessmentItems}의 순서와 일치해야 합니다.
+	 */
+	public void registerSubmission(final Long memberId, final List<List<String>> answers) {
+		final AssessmentSubmission assessmentSubmission = AssessmentSubmission.of(this, memberId);
+		// sequence를 기준으로 정렬한다.
+		this.assessmentItems.sort((a, b) -> a.getSequence() - b.getSequence());
+
+		for (int i = 0; i < assessmentItems.size(); i ++) {
+			assessmentSubmission.addItemSubmission(assessmentItems.get(i), answers.get(i));
+		}
+
+		assessmentSubmissions.add(assessmentSubmission);
 	}
 
 	/**

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/entity/AssessmentItemSubmission.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/entity/AssessmentItemSubmission.java
@@ -1,0 +1,67 @@
+package kr.co.mathrank.domain.problem.assessment.entity;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString(exclude = "submission")
+public class AssessmentItemSubmission {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	private AssessmentSubmission submission;
+
+	/** 이 답안이 속한 원본 평가 문항 */
+	@ManyToOne(fetch = FetchType.LAZY)
+	private AssessmentItem assessmentItem;
+
+	/**
+	 * 사용자가 제출한 답안.
+	 * <p>
+	 * 주관식 단답형 등 정답이 여러 개일 수 있는 경우를 대비해 List로 관리합니다.
+	 * DB에는 JSON 형태로 저장됩니다.
+	 * </p>
+	 */
+	@JdbcTypeCode(SqlTypes.JSON)
+	private List<String> submittedAnswer;
+
+	static AssessmentItemSubmission of(final AssessmentSubmission submission, final AssessmentItem assessmentItem, final List<String> submittedAnswer) {
+		final AssessmentItemSubmission assessmentItemSubmission = new AssessmentItemSubmission();
+		assessmentItemSubmission.submission = submission;
+		assessmentItemSubmission.assessmentItem = assessmentItem;
+		assessmentItemSubmission.submittedAnswer = submittedAnswer;
+
+		return assessmentItemSubmission;
+	}
+
+	/**
+	 * 제출된 답안 리스트를 반환합니다.
+	 *
+	 * <p>반환되는 리스트는 변경할 수 없는
+	 * {@link java.util.Collections#unmodifiableList(List)}로 감싸져 있으므로,
+	 * 호출자가 내용을 수정하려고 하면 {@link UnsupportedOperationException}이 발생합니다.</p>
+	 *
+	 * @return 제출된 답안의 불변 리스트
+	 */
+	public List<String> getSubmittedAnswer() {
+		return Collections.unmodifiableList(submittedAnswer);
+	}
+}

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/entity/AssessmentSubmission.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/entity/AssessmentSubmission.java
@@ -1,0 +1,66 @@
+package kr.co.mathrank.domain.problem.assessment.entity;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.hibernate.annotations.CreationTimestamp;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AssessmentSubmission {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	private Assessment assessment;
+
+	private Long memberId;
+
+	@OneToMany(mappedBy = "submission", orphanRemoval = true, cascade = CascadeType.PERSIST)
+	private final List<AssessmentItemSubmission> submittedItemAnswers = new ArrayList<>();
+
+	@CreationTimestamp
+	private LocalDateTime submittedAt;
+
+	static AssessmentSubmission of(final Assessment assessment, final Long memberId) {
+		final AssessmentSubmission assessmentSubmission = new AssessmentSubmission();
+		assessmentSubmission.assessment = assessment;
+		assessmentSubmission.memberId = memberId;
+
+		return assessmentSubmission;
+	}
+
+	void addItemSubmission(final AssessmentItem assessmentItem, final List<String> submittedAnswer) {
+		final AssessmentItemSubmission assessmentItemSubmission = AssessmentItemSubmission.of(this, assessmentItem, submittedAnswer);
+		this.submittedItemAnswers.add(assessmentItemSubmission);
+	}
+
+	/**
+	 * 제출된 모든 문항 답안을 반환합니다.
+	 *
+	 * <p>반환되는 리스트는 {@link java.util.Collections#unmodifiableList(List)}로
+	 * 감싸져 있어 외부에서 수정할 수 없습니다.
+	 * 리스트의 요소를 변경하려 하면 {@link UnsupportedOperationException}이 발생합니다.</p>
+	 *
+	 * @return 제출된 문항 답안들의 불변 리스트
+	 */
+	public List<AssessmentItemSubmission> getSubmittedItemAnswers() {
+		return Collections.unmodifiableList(submittedItemAnswers);
+	}
+}

--- a/domain/mathrank-problem-assessment-domain/src/test/java/kr/co/mathrank/domain/problem/assessment/entity/AssessmentItemSubmissionTest.java
+++ b/domain/mathrank-problem-assessment-domain/src/test/java/kr/co/mathrank/domain/problem/assessment/entity/AssessmentItemSubmissionTest.java
@@ -1,0 +1,46 @@
+package kr.co.mathrank.domain.problem.assessment.entity;
+
+import java.time.Duration;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import kr.co.mathrank.domain.problem.assessment.repository.AssessmentRepository;
+
+@DataJpaTest(showSql = true)
+class AssessmentItemSubmissionTest {
+	@PersistenceContext
+	private EntityManager entityManager;
+	@Autowired
+	private AssessmentRepository assessmentRepository;
+
+	@Test
+	void 시험지에_제출된_정답은_DB에_json_형식으로_저장된다() {
+		// given
+		final Assessment assessment = Assessment.of(1L, "test", Duration.ofMinutes(10));
+		// 한 문제 등록
+		assessment.replaceItems(List.of(AssessmentItem.of(1L, 10)));
+		// 문항에 대한 답안 내용 (정답이 여러 개일 수 있음을 가정)
+		final List<String> submittedAnswer = List.of("1", "2", "3");
+		assessment.registerSubmission(1L, List.of(submittedAnswer));
+
+		// when
+		final Long assessmentId = assessmentRepository.save(assessment).getId();
+		entityManager.flush();
+		entityManager.clear();
+
+		// then
+		final Assessment savedAssessment = assessmentRepository.findById(assessmentId)
+			.orElseThrow();
+		final AssessmentSubmission submission = savedAssessment.getAssessmentSubmissions().getFirst();
+		final AssessmentItemSubmission itemSubmission = submission.getSubmittedItemAnswers().getFirst();
+
+		// DB에 저장된 JSON 값이 올바르게 역직렬화되는지 확인
+		Assertions.assertIterableEquals(submittedAnswer, itemSubmission.getSubmittedAnswer());
+	}
+}


### PR DESCRIPTION
## 📝 작업 내용

`Assessment`에 각 사용자가 답안지를 제출하는 기능입니다. 

- 각 문제의 답안은 여러개(복수형)일 수 있음으로, 디비에 `JSON`형식으로 저장한다. 
  - 불필요한 테이블 관리 비용 제거
- `Assessment` 도메인을 통해 답안지 추가 하도록 관리 
  - 답안 갯수 및 조회는 `unmodifialbleList`로 안전하게 관리