### PR TITLE
개별문제 조회, 결과에 풀이 여부 포함되도록 구현

### DIFF
--- a/app/api/mathrank-problem-single-read-api/src/main/java/kr/co/mathrank/app/api/problem/single/read/SingleProblemReadController.java
+++ b/app/api/mathrank-problem-single-read-api/src/main/java/kr/co/mathrank/app/api/problem/single/read/SingleProblemReadController.java
@@ -10,8 +10,9 @@ import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.constraints.Max;
 import kr.co.mathrank.app.api.common.authentication.Authorization;
+import kr.co.mathrank.app.api.common.authentication.LoginInfo;
+import kr.co.mathrank.app.api.common.authentication.MemberPrincipal;
 import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemReadModelPageResult;
 import kr.co.mathrank.domain.problem.single.read.service.SingleProblemQueryService;
 import lombok.RequiredArgsConstructor;
@@ -26,12 +27,17 @@ public class SingleProblemReadController {
 	@Operation(summary = "풀이 시도 가능한 개별문제 페이징 조회 API")
 	@Authorization(openedForAll = true)
 	public ResponseEntity<SingleProblemReadModelPageResult> getSingleProblems(
+		@LoginInfo final MemberPrincipal memberPrincipal,
 		@ModelAttribute @ParameterObject final SingleProblemQueryRequest query,
 		@Range(min = 1, max = 1000) @RequestParam(defaultValue = "1") final Integer pageNumber,
 		@Range(min = 1, max = 20) @RequestParam(defaultValue = "1") final Integer pageSize
 	) {
-		final SingleProblemReadModelPageResult result = singleProblemQueryService.queryPage(query.toQuery(), pageSize,
-			pageNumber);
+		final SingleProblemReadModelPageResult result = singleProblemQueryService.queryPage(
+			query.toQuery(),
+			memberPrincipal.memberId(),
+			pageSize,
+			pageNumber
+		);
 		return ResponseEntity.ok(result);
 	}
 }

--- a/app/consumer/mathrank-problem-single-consumer/src/main/java/kr/co/mathrank/app/consumer/problem/single/SingleProblemStatisticsUpdatedPayload.java
+++ b/app/consumer/mathrank-problem-single-consumer/src/main/java/kr/co/mathrank/app/consumer/problem/single/SingleProblemStatisticsUpdatedPayload.java
@@ -5,6 +5,9 @@ import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemAttemptStatsUp
 
 public record SingleProblemStatisticsUpdatedPayload(
 	Long singleProblemId,
+	Long problemId,
+	Long memberId,
+	Boolean success,
 	Long firstTrySuccessCount,
 	Long totalAttemptedCount,
 	Long attemptedUserDistinctCount
@@ -12,6 +15,8 @@ public record SingleProblemStatisticsUpdatedPayload(
 	public SingleProblemAttemptStatsUpdateCommand toCommand() {
 		return new SingleProblemAttemptStatsUpdateCommand(
 			this.singleProblemId,
+			memberId,
+			success,
 			this.firstTrySuccessCount,
 			this.totalAttemptedCount,
 			this.attemptedUserDistinctCount

--- a/app/consumer/mathrank-problem-single-consumer/src/test/java/kr/co/mathrank/app/consumer/problem/single/SingleProblemReadModelConsumerTest.java
+++ b/app/consumer/mathrank-problem-single-consumer/src/test/java/kr/co/mathrank/app/consumer/problem/single/SingleProblemReadModelConsumerTest.java
@@ -15,7 +15,6 @@ import org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.test.context.EmbeddedKafka;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
@@ -106,7 +105,7 @@ class SingleProblemReadModelConsumerTest {
 		final long firstTrySuccessCount = 1L;
 		final long attemptedUserDistinctCount = 2L;
 		final long totalAttemptedCount = 3L;
-		final var payload = new SingleProblemStatisticsUpdatedPayload(singleProblemId, firstTrySuccessCount,
+		final var payload = new SingleProblemStatisticsUpdatedPayload(singleProblemId, 2L, 3L, true, firstTrySuccessCount,
 			totalAttemptedCount, attemptedUserDistinctCount);
 		final Event<SingleProblemStatisticsUpdatedPayload> event = Event.of(1L, payload);
 		final String message = event.serialize();

--- a/app/consumer/mathrank-problem-single-read-consumer-monolith/src/main/java/kr/co/mathrank/app/consumer/problem/single/read/consumer/monolith/EventPayloads.java
+++ b/app/consumer/mathrank-problem-single-read-consumer-monolith/src/main/java/kr/co/mathrank/app/consumer/problem/single/read/consumer/monolith/EventPayloads.java
@@ -46,6 +46,8 @@ public class EventPayloads {
 		SingleProblemAttemptStatsUpdateCommand toCommand() {
 			return new SingleProblemAttemptStatsUpdateCommand(
 				singleProblemId,
+				memberId,
+				success,
 				firstTrySuccessCount,
 				totalAttemptedCount,
 				attemptedUserDistinctCount

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/dto/SingleProblemAttemptStatsUpdateCommand.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/dto/SingleProblemAttemptStatsUpdateCommand.java
@@ -1,12 +1,14 @@
 package kr.co.mathrank.domain.problem.single.read.dto;
 
-import java.time.LocalDateTime;
-
 import jakarta.validation.constraints.NotNull;
 
 public record SingleProblemAttemptStatsUpdateCommand(
 	@NotNull
 	Long singleProblemId, // singleProblemId is different from problemId
+	@NotNull
+	Long memberId,
+	@NotNull
+	Boolean success,
 	@NotNull
 	Long firstTrySuccessCount,
 	@NotNull

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/dto/SingleProblemReadModelResult.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/dto/SingleProblemReadModelResult.java
@@ -6,6 +6,7 @@ import kr.co.mathrank.domain.problem.single.read.entity.SingleProblemReadModel;
 
 public record SingleProblemReadModelResult(
 	Long id, // single problem id
+	Boolean successAtFirstTry, // null: 푼적 없음, true: 성공해썽, false: 실패해썽
 	Long problemId, // problem id
 	String singleProblemName,
 	String problemImage,
@@ -17,9 +18,10 @@ public record SingleProblemReadModelResult(
 	Long attemptedUserDistinctCount, // 해당 문제를 풀려고 한 사용자 수
 	Double accuracy // 정답률
 ) {
-	public static SingleProblemReadModelResult from(final SingleProblemReadModel model) {
+	public static SingleProblemReadModelResult from(final SingleProblemReadModel model, final Long requestMemberId) {
 		return new SingleProblemReadModelResult(
 			model.getId(),
+			model.getSolvedStatus(requestMemberId),
 			model.getProblemId(),
 			model.getSingleProblemName(),
 			model.getProblemImage(),

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/dto/SingleProblemReadModelResult.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/dto/SingleProblemReadModelResult.java
@@ -18,10 +18,10 @@ public record SingleProblemReadModelResult(
 	Long attemptedUserDistinctCount, // 해당 문제를 풀려고 한 사용자 수
 	Double accuracy // 정답률
 ) {
-	public static SingleProblemReadModelResult from(final SingleProblemReadModel model, final Long requestMemberId) {
+	public static SingleProblemReadModelResult from(final SingleProblemReadModel model, final Boolean successAtFirstTry) {
 		return new SingleProblemReadModelResult(
 			model.getId(),
-			model.getSolvedStatus(requestMemberId),
+			successAtFirstTry,
 			model.getProblemId(),
 			model.getSingleProblemName(),
 			model.getProblemImage(),

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/entity/SingleProblemReadModel.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/entity/SingleProblemReadModel.java
@@ -3,11 +3,13 @@ package kr.co.mathrank.domain.problem.single.read.entity;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDateTime;
+import java.util.HashSet;
 import java.util.Set;
 
 import org.hibernate.annotations.BatchSize;
 import org.springframework.data.domain.Persistable;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
@@ -81,8 +83,8 @@ public class SingleProblemReadModel implements Persistable<Long> {
 	private LocalDateTime createdAt; // singleProblem이 등록된 시점
 
 	@BatchSize(size = 100)
-	@OneToMany(mappedBy = "singleProblemReadModel")
-	private Set<SingleProblemSolver> solvers;
+	@OneToMany(mappedBy = "singleProblemReadModel", cascade = CascadeType.REMOVE)
+	private Set<SingleProblemSolver> solvers = new HashSet<>();
 
 	public static SingleProblemReadModel of(
 		final Long singleProblemId,
@@ -113,6 +115,14 @@ public class SingleProblemReadModel implements Persistable<Long> {
 		model.isNew = true;
 
 		return model;
+	}
+
+	public Boolean getSolvedStatus(final Long memberId) {
+		return this.getSolvers().stream()
+			.filter(singleProblemSolver -> singleProblemSolver.getMemberId().equals(memberId))
+			.map(SingleProblemSolver::isSuccess)
+			.findAny()
+			.orElse(null); // 푼 적이 없어용!
 	}
 
 	@PrePersist

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/entity/SingleProblemReadModel.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/entity/SingleProblemReadModel.java
@@ -3,7 +3,9 @@ package kr.co.mathrank.domain.problem.single.read.entity;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDateTime;
+import java.util.Set;
 
+import org.hibernate.annotations.BatchSize;
 import org.springframework.data.domain.Persistable;
 
 import jakarta.persistence.Column;
@@ -13,6 +15,7 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
@@ -76,6 +79,10 @@ public class SingleProblemReadModel implements Persistable<Long> {
 
 	@Setter(AccessLevel.PRIVATE)
 	private LocalDateTime createdAt; // singleProblem이 등록된 시점
+
+	@BatchSize(size = 100)
+	@OneToMany(mappedBy = "singleProblemReadModel")
+	private Set<SingleProblemSolver> solvers;
 
 	public static SingleProblemReadModel of(
 		final Long singleProblemId,

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/entity/SingleProblemReadModel.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/entity/SingleProblemReadModel.java
@@ -3,7 +3,9 @@ package kr.co.mathrank.domain.problem.single.read.entity;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.hibernate.annotations.BatchSize;
@@ -84,7 +86,7 @@ public class SingleProblemReadModel implements Persistable<Long> {
 
 	@BatchSize(size = 100)
 	@OneToMany(mappedBy = "singleProblemReadModel", cascade = CascadeType.REMOVE)
-	private Set<SingleProblemSolver> solvers = new HashSet<>();
+	private final List<SingleProblemSolver> solvers = new ArrayList<>();
 
 	public static SingleProblemReadModel of(
 		final Long singleProblemId,

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/entity/SingleProblemReadModel.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/entity/SingleProblemReadModel.java
@@ -117,14 +117,6 @@ public class SingleProblemReadModel implements Persistable<Long> {
 		return model;
 	}
 
-	public Boolean getSolvedStatus(final Long memberId) {
-		return this.getSolvers().stream()
-			.filter(singleProblemSolver -> singleProblemSolver.getMemberId().equals(memberId))
-			.map(SingleProblemSolver::isSuccess)
-			.findAny()
-			.orElse(null); // 푼 적이 없어용!
-	}
-
 	@PrePersist
 	@PreUpdate
 	void updateAccuracy() {

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/entity/SingleProblemSolver.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/entity/SingleProblemSolver.java
@@ -11,6 +11,7 @@ import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Entity
 @Table(
@@ -21,6 +22,7 @@ import lombok.NoArgsConstructor;
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString(exclude = "singleProblemReadModel")
 public class SingleProblemSolver {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/entity/SingleProblemSolver.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/entity/SingleProblemSolver.java
@@ -16,7 +16,7 @@ import lombok.NoArgsConstructor;
 @Table(
 	uniqueConstraints = @UniqueConstraint(
 		name = "unique_memberId_singleProblemId",
-		columnNames = {"member_id", "id"}
+		columnNames = {"member_id", "single_problem_read_model_id"}
 	)
 )
 @Getter

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/entity/SingleProblemSolver.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/entity/SingleProblemSolver.java
@@ -1,0 +1,44 @@
+package kr.co.mathrank.domain.problem.single.read.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+	uniqueConstraints = @UniqueConstraint(
+		name = "unique_memberId_singleProblemId",
+		columnNames = {"member_id", "id"}
+	)
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SingleProblemSolver {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private Long memberId;
+
+	private boolean success; // success or fail 둘 중 하나
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	private SingleProblemReadModel singleProblemReadModel;
+
+	public static SingleProblemSolver of(final SingleProblemReadModel singleProblemReadModel, final Long memberId, final boolean success) {
+		final SingleProblemSolver singleProblemSolver = new SingleProblemSolver();
+		singleProblemSolver.memberId = memberId;
+		singleProblemSolver.singleProblemReadModel =singleProblemReadModel;
+		singleProblemSolver.success = success;
+
+		return singleProblemSolver;
+	}
+}

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/repository/SingleProblemSolverRepository.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/repository/SingleProblemSolverRepository.java
@@ -15,4 +15,6 @@ public interface SingleProblemSolverRepository extends JpaRepository<SingleProbl
 	@Query("SELECT sps FROM SingleProblemSolver sps WHERE sps.singleProblemReadModel.id = :singleProblemId AND sps.memberId = :memberId")
 	Optional<SingleProblemSolver> findSolverForShare(@Param("memberId") Long memberId,
 		@Param("singleProblemId") Long singleProblemId);
+
+	Optional<SingleProblemSolver> findByMemberIdAndSingleProblemReadModelId(Long memberId, Long singleProblemId);
 }

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/repository/SingleProblemSolverRepository.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/repository/SingleProblemSolverRepository.java
@@ -1,0 +1,18 @@
+package kr.co.mathrank.domain.problem.single.read.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import jakarta.persistence.LockModeType;
+import kr.co.mathrank.domain.problem.single.read.entity.SingleProblemSolver;
+
+public interface SingleProblemSolverRepository extends JpaRepository<SingleProblemSolver, Long> {
+	@Lock(LockModeType.PESSIMISTIC_READ)
+	@Query("SELECT sps FROM SingleProblemSolver sps WHERE sps.id = :singleProblemId AND sps.memberId = :memberId")
+	Optional<SingleProblemSolver> findSolverForShare(@Param("memberId") Long memberId,
+		@Param("singleProblemId") Long singleProblemId);
+}

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/repository/SingleProblemSolverRepository.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/repository/SingleProblemSolverRepository.java
@@ -12,7 +12,7 @@ import kr.co.mathrank.domain.problem.single.read.entity.SingleProblemSolver;
 
 public interface SingleProblemSolverRepository extends JpaRepository<SingleProblemSolver, Long> {
 	@Lock(LockModeType.PESSIMISTIC_READ)
-	@Query("SELECT sps FROM SingleProblemSolver sps WHERE sps.id = :singleProblemId AND sps.memberId = :memberId")
+	@Query("SELECT sps FROM SingleProblemSolver sps WHERE sps.singleProblemReadModel.id = :singleProblemId AND sps.memberId = :memberId")
 	Optional<SingleProblemSolver> findSolverForShare(@Param("memberId") Long memberId,
 		@Param("singleProblemId") Long singleProblemId);
 }

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/repository/SingleProblemSolverRepository.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/repository/SingleProblemSolverRepository.java
@@ -1,5 +1,7 @@
 package kr.co.mathrank.domain.problem.single.read.repository;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,6 +10,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import jakarta.persistence.LockModeType;
+import kr.co.mathrank.domain.problem.single.read.entity.SingleProblemReadModel;
 import kr.co.mathrank.domain.problem.single.read.entity.SingleProblemSolver;
 
 public interface SingleProblemSolverRepository extends JpaRepository<SingleProblemSolver, Long> {
@@ -16,5 +19,5 @@ public interface SingleProblemSolverRepository extends JpaRepository<SingleProbl
 	Optional<SingleProblemSolver> findSolverForShare(@Param("memberId") Long memberId,
 		@Param("singleProblemId") Long singleProblemId);
 
-	Optional<SingleProblemSolver> findByMemberIdAndSingleProblemReadModelId(Long memberId, Long singleProblemId);
+	List<SingleProblemSolver> findByMemberIdAndSingleProblemReadModelIn(Long memberId, Collection<SingleProblemReadModel> singleProblemReadModels);
 }

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemQueryService.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemQueryService.java
@@ -1,6 +1,9 @@
 package kr.co.mathrank.domain.problem.single.read.service;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 
 import org.hibernate.validator.constraints.Range;
 import org.springframework.stereotype.Service;
@@ -26,20 +29,37 @@ public class SingleProblemQueryService {
 	private final SingleProblemReadModelRepository singleProblemRepository;
 	private final SingleProblemSolverRepository singleProblemSolverRepository;
 
+	/**
+	 * 필터 조건에 맞는 개별 문제 목록을 페이지네이션하여 조회합니다.
+	 * <p>
+	 * 각 문제에 대해 현재 사용자의 풀이 성공 여부(성공, 실패, 시도 안 함)를 함께 반환합니다.
+	 *
+	 * @param query        검색 필터 조건(문제 이름, 카테고리, 난이도 등)
+	 * @param memberId     조회하는 사용자의 ID
+	 * @param pageSize     한 페이지에 표시할 문제의 수 (1~20)
+	 * @param pageNumber   조회할 페이지 번호 (1부터 시작)
+	 * @return 페이지네이션된 문제 목록 및 관련 정보
+	 */
 	public SingleProblemReadModelPageResult queryPage(
 		@NotNull @Valid final SingleProblemReadModelQuery query,
 		@NotNull final Long memberId,
 		@NotNull @Range(min = 1, max = 20) final Integer pageSize,
 		@NotNull @Range(max = 1000) final Integer pageNumber // 페이지 번호 (1부터 시작). 내부 offset 계산 시 사용됨: offset = (pageNumber - 1) * pageSize
 	) {
+		// 1. 조건에 맞는 문제 목록을 페이지네이션하여 조회
 		final List<SingleProblemReadModel> readModels = singleProblemRepository.queryPage(query, pageSize, pageNumber);
+		// 2. 조건에 맞는 전체 문제 개수 조회 (페이지네이션 계산용)
 		final Long count = singleProblemRepository.count(query);
 
+		// 3. 조회된 문제 목록에 대한 현재 사용자의 풀이 기록을 Map 형태로 한 번에 조회 (메모리 오버 플러우 방지)
+		final Map<Long, SingleProblemSolver> solverMap = getMap(readModels, memberId);
+
+		// 4. 최종 결과 형태로 변환하여 반환
 		return new SingleProblemReadModelPageResult(
 			readModels.stream()
 				.map(model -> SingleProblemReadModelResult.from(
 					model,
-					getTryStatus(model.getId(), memberId)))
+					getTryStatus(model.getId(), solverMap)))
 				.toList(),
 			pageNumber,
 			pageSize,
@@ -47,9 +67,44 @@ public class SingleProblemQueryService {
 			));
 	}
 
-	private Boolean getTryStatus(final Long singleProblemId, final Long requestMemberId) {
-		return singleProblemSolverRepository.findByMemberIdAndSingleProblemReadModelId(requestMemberId, singleProblemId)
-			.map(SingleProblemSolver::isSuccess) // 존재하면 풀이 성공 여부
-			.orElse(null); // 존재하지 않으면 null
+	/**
+	 * 특정 문제에 대한 사용자의 풀이 상태를 반환합니다.
+	 *
+	 * @param singleProblemId 확인할 문제의 ID
+	 * @param solverMap       사용자의 풀이 기록을 담고 있는 맵
+	 * @return                성공 시 {@code true}, 실패 시 {@code false}, 푼 적이 없으면 {@code null}
+	 */
+	private Boolean getTryStatus(final Long singleProblemId, final Map<Long, SingleProblemSolver> solverMap) {
+		if (solverMap.containsKey(singleProblemId)) {
+			// 푼적이 있을때
+			return solverMap.get(singleProblemId).isSuccess(); // 풀이 결과 리턴
+		} else {
+			// 푼적이 없을때
+			return null;
+		}
+	}
+
+	/**
+	 * (메모리 오버 플러우 방지)
+	 *
+	 * 주어진 문제 목록에 대해 특정 사용자의 풀이 기록({@link SingleProblemSolver})을 조회하여
+	 * 빠른 조회를 위한 {@code Map} 형태로 반환합니다.
+	 * <p>
+	 * {@code IN} 쿼리를 사용하여 풀이 기록을 한 번에 가져옵니다.
+	 *
+	 * @param models          조회할 문제 엔티티 목록
+	 * @param requestMemberId 풀이 기록을 조회할 사용자의 ID
+	 * @return                문제 ID를 key로, {@code SingleProblemSolver}를 value로 갖는 Map
+	 */
+	private Map<Long, SingleProblemSolver> getMap(final List<SingleProblemReadModel> models, final Long requestMemberId) {
+		final Map<Long, SingleProblemSolver> map = new HashMap<>();
+
+		final List<SingleProblemSolver> solvers = singleProblemSolverRepository.findByMemberIdAndSingleProblemReadModelIn(requestMemberId, models);
+
+		for (final var solver : solvers) {
+			map.put(solver.getSingleProblemReadModel().getId(), solver);
+		}
+
+		return map;
 	}
 }

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemQueryService.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemQueryService.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.hibernate.validator.constraints.Range;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 
 import jakarta.validation.Valid;
@@ -22,8 +23,10 @@ import lombok.RequiredArgsConstructor;
 public class SingleProblemQueryService {
 	private final SingleProblemReadModelRepository singleProblemRepository;
 
+	@Transactional
 	public SingleProblemReadModelPageResult queryPage(
 		@NotNull @Valid final SingleProblemReadModelQuery query,
+		@NotNull final Long memberId,
 		@NotNull @Range(min = 1, max = 20) final Integer pageSize,
 		@NotNull @Range(max = 1000) final Integer pageNumber // 페이지 번호 (1부터 시작). 내부 offset 계산 시 사용됨: offset = (pageNumber - 1) * pageSize
 	) {
@@ -32,7 +35,7 @@ public class SingleProblemQueryService {
 
 		return new SingleProblemReadModelPageResult(
 			readModels.stream()
-				.map(SingleProblemReadModelResult::from)
+				.map(model -> SingleProblemReadModelResult.from(model, memberId))
 				.toList(),
 			pageNumber,
 			pageSize,

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemQueryService.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemQueryService.java
@@ -14,7 +14,9 @@ import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemReadModelPageR
 import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemReadModelQuery;
 import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemReadModelResult;
 import kr.co.mathrank.domain.problem.single.read.entity.SingleProblemReadModel;
+import kr.co.mathrank.domain.problem.single.read.entity.SingleProblemSolver;
 import kr.co.mathrank.domain.problem.single.read.repository.SingleProblemReadModelRepository;
+import kr.co.mathrank.domain.problem.single.read.repository.SingleProblemSolverRepository;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -22,8 +24,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class SingleProblemQueryService {
 	private final SingleProblemReadModelRepository singleProblemRepository;
+	private final SingleProblemSolverRepository singleProblemSolverRepository;
 
-	@Transactional
 	public SingleProblemReadModelPageResult queryPage(
 		@NotNull @Valid final SingleProblemReadModelQuery query,
 		@NotNull final Long memberId,
@@ -35,11 +37,19 @@ public class SingleProblemQueryService {
 
 		return new SingleProblemReadModelPageResult(
 			readModels.stream()
-				.map(model -> SingleProblemReadModelResult.from(model, memberId))
+				.map(model -> SingleProblemReadModelResult.from(
+					model,
+					getTryStatus(model.getId(), memberId)))
 				.toList(),
 			pageNumber,
 			pageSize,
 			PageUtil.getNextPages(pageSize, pageNumber, count, readModels.size()
 			));
+	}
+
+	private Boolean getTryStatus(final Long singleProblemId, final Long requestMemberId) {
+		return singleProblemSolverRepository.findByMemberIdAndSingleProblemReadModelId(requestMemberId, singleProblemId)
+			.map(SingleProblemSolver::isSuccess) // 존재하면 풀이 성공 여부
+			.orElse(null); // 존재하지 않으면 null
 	}
 }

--- a/domain/mathrank-problem-single-read-domain/src/test/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemQueryServiceTest.java
+++ b/domain/mathrank-problem-single-read-domain/src/test/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemQueryServiceTest.java
@@ -3,6 +3,7 @@ package kr.co.mathrank.domain.problem.single.read.service;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.List;
 
 import org.junit.jupiter.api.AfterEach;
@@ -94,14 +95,15 @@ class SingleProblemQueryServiceTest {
 		final List<SingleProblemReadModelResult> results = result.queryResults();
 
 		// 1번 문제부터 정렬
-		results.stream()
-			.sorted((a, b) -> a.problemId().compareTo(b.problemId()));
+		final List<SingleProblemReadModelResult> sorted = results.stream()
+			.sorted(Comparator.comparing(SingleProblemReadModelResult::problemId))
+			.toList();
 
 		Assertions.assertAll(
-			() -> Assertions.assertEquals(3, results.size()),
-			() -> Assertions.assertTrue(results.get(0).successAtFirstTry()),
-			() -> Assertions.assertFalse(results.get(1).successAtFirstTry()),
-			() -> Assertions.assertNull(results.get(2).successAtFirstTry())
+			() -> Assertions.assertEquals(3, sorted.size()),
+			() -> Assertions.assertTrue(sorted.get(0).successAtFirstTry()),
+			() -> Assertions.assertFalse(sorted.get(1).successAtFirstTry()),
+			() -> Assertions.assertNull(sorted.get(2).successAtFirstTry())
 		);
 	}
 

--- a/domain/mathrank-problem-single-read-domain/src/test/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemQueryServiceTest.java
+++ b/domain/mathrank-problem-single-read-domain/src/test/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemQueryServiceTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,8 +19,10 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 import jakarta.validation.ConstraintViolationException;
 import kr.co.mathrank.domain.problem.core.Difficulty;
+import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemAttemptStatsUpdateCommand;
 import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemReadModelPageResult;
 import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemReadModelQuery;
+import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemReadModelResult;
 import kr.co.mathrank.domain.problem.single.read.entity.SingleProblemReadModel;
 import kr.co.mathrank.domain.problem.single.read.repository.SingleProblemReadModelRepository;
 
@@ -30,11 +33,12 @@ import kr.co.mathrank.domain.problem.single.read.repository.SingleProblemReadMod
 	}
 )
 @Testcontainers
-@Transactional
 class SingleProblemQueryServiceTest {
 
 	@Autowired
 	private SingleProblemQueryService queryService;
+	@Autowired
+	private SingleProblemUpdateService singleProblemUpdateService;
 
 	@Autowired
 	private SingleProblemReadModelRepository repository;
@@ -44,6 +48,8 @@ class SingleProblemQueryServiceTest {
 		.withDatabaseName("testdb")
 		.withUsername("user")
 		.withPassword("password");
+	@Autowired
+	private SingleProblemReadModelRepository singleProblemReadModelRepository;
 
 	@DynamicPropertySource
 	static void setProperties(DynamicPropertyRegistry registry) {
@@ -53,14 +59,64 @@ class SingleProblemQueryServiceTest {
 	}
 
 	@Test
-	void 오프셋이_20_000초과로_조회할_수_없다() {
-		final SingleProblemReadModelQuery query = new SingleProblemReadModelQuery(null, "singleProblemName", "math", null, Difficulty.MID, Difficulty.MID, 10, 30, null, null);
+	void 내가_푼_문제가_표시된다() {
+		final Long memberId = 10L;
 
-		Assertions.assertThrows(ConstraintViolationException.class, () -> queryService.queryPage(query, 20, 1001));
-		Assertions.assertThrows(ConstraintViolationException.class, () -> queryService.queryPage(query, 21, 1000));
+		repository.saveAll(List.of(
+			SingleProblemReadModel.of(1L, 1L, "singleProblemName","img", "math", null, Difficulty.MID, 0L, 0L, 0L, LocalDateTime.now()),
+			SingleProblemReadModel.of(2L, 2L, "singleProblemName","img", "math", null, Difficulty.MID, 0L, 0L, 0L, LocalDateTime.now()),
+			SingleProblemReadModel.of(3L, 3L, "singleProblemName","img", "math", null, Difficulty.MID, 0L, 0L, 0L, LocalDateTime.now())
+		));
+
+		// 1번 문제는 첫시도에풀이 성공 표시
+		singleProblemUpdateService.updateAttemptStatistics(new SingleProblemAttemptStatsUpdateCommand(
+			1L, memberId, true, 1L, 1L, 1L
+		));
+		// 2번 문제는 첫시도에 풀이 실패 표시
+		singleProblemUpdateService.updateAttemptStatistics(new SingleProblemAttemptStatsUpdateCommand(
+			2L, memberId, false, 1L, 1L, 1L
+		));
+		// 3번은 풀이 시도 X
+
+		final SingleProblemReadModelQuery query = new SingleProblemReadModelQuery(
+			null,
+			null,
+			null,
+			null,
+			null,
+			null,
+			null,
+			null,
+			null,
+			null
+		);
+		final SingleProblemReadModelPageResult result = queryService.queryPage(query, memberId, 10, 1);
+		final List<SingleProblemReadModelResult> results = result.queryResults();
+
+		// 1번 문제부터 정렬
+		results.stream()
+			.sorted((a, b) -> a.problemId().compareTo(b.problemId()));
+
+		Assertions.assertAll(
+			() -> Assertions.assertEquals(3, results.size()),
+			() -> Assertions.assertTrue(results.get(0).successAtFirstTry()),
+			() -> Assertions.assertFalse(results.get(1).successAtFirstTry()),
+			() -> Assertions.assertNull(results.get(2).successAtFirstTry())
+		);
 	}
 
 	@Test
+	@Transactional
+	void 오프셋이_20_000초과로_조회할_수_없다() {
+		final SingleProblemReadModelQuery query = new SingleProblemReadModelQuery(null, "singleProblemName", "math", null, Difficulty.MID, Difficulty.MID, 10, 30, null, null);
+		final Long memberId = 10L;
+
+		Assertions.assertThrows(ConstraintViolationException.class, () -> queryService.queryPage(query, memberId, 20, 1001));
+		Assertions.assertThrows(ConstraintViolationException.class, () -> queryService.queryPage(query, memberId, 21, 1000));
+	}
+
+	@Test
+	@Transactional
 	void 정답률과_난이도조건으로_페이징_조회한다() {
 		// Given
 		repository.saveAll(List.of(
@@ -86,7 +142,7 @@ class SingleProblemQueryServiceTest {
 		);
 
 		// When
-		final SingleProblemReadModelPageResult result = queryService.queryPage(query, 2, 1);
+		final SingleProblemReadModelPageResult result = queryService.queryPage(query, 1000L, 2, 1);
 
 		// Then
 		// 두개가 나와야 한다
@@ -96,12 +152,17 @@ class SingleProblemQueryServiceTest {
 		Assertions.assertEquals(1, result.possibleNextPageNumbers().size()); // 다음 페이지가 1개 존재한다
 
 		// 다음 페이지도 테스트
-		final SingleProblemReadModelPageResult nextResult = queryService.queryPage(query, 2, 2);
+		final SingleProblemReadModelPageResult nextResult = queryService.queryPage(query, 1000L, 2, 2);
 
 		// 다음 페이지에 1개가존재해야한다
 		Assertions.assertEquals(1, nextResult.queryResults().size());
 
 		// 다음 페이지는 없다
 		Assertions.assertTrue(nextResult.possibleNextPageNumbers().isEmpty());
+	}
+
+	@AfterEach
+	void clear() {
+		singleProblemReadModelRepository.deleteAll();
 	}
 }

--- a/domain/mathrank-problem-single-read-domain/src/test/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemUpdateServiceTest.java
+++ b/domain/mathrank-problem-single-read-domain/src/test/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemUpdateServiceTest.java
@@ -170,7 +170,7 @@ class SingleProblemUpdateServiceTest {
 
 		// when
 		singleProblemUpdateService.updateAttemptStatistics(new SingleProblemAttemptStatsUpdateCommand(
-			problemId, 2L, 6L, 11L
+			problemId, 10L, true, 2L, 6L, 11L
 		));
 
 		entityManager.flush();
@@ -200,7 +200,7 @@ class SingleProblemUpdateServiceTest {
 
 		// when
 		singleProblemUpdateService.updateAttemptStatistics(new SingleProblemAttemptStatsUpdateCommand(
-			problemId, 999L, 6L, 10L
+			problemId, 10L, true, 999L, 6L, 10L
 		));
 
 		entityManager.flush();
@@ -222,7 +222,7 @@ class SingleProblemUpdateServiceTest {
 		// expect
 		Assertions.assertThrows(CannotFoundProblemException.class, () -> {
 			singleProblemUpdateService.updateAttemptStatistics(new SingleProblemAttemptStatsUpdateCommand(
-				nonexistentId, 1L, 2L, 3L
+				nonexistentId, 10L, true, 1L, 2L, 3L
 			));
 		});
 	}
@@ -255,6 +255,8 @@ class SingleProblemUpdateServiceTest {
 						singleProblemUpdateService.updateAttemptStatistics(
 							new SingleProblemAttemptStatsUpdateCommand(
 								problemId,
+								10L,
+								true,
 								attemptCount / 10,        // firstTrySuccessCount
 								attemptCount,         // totalCount
 								attemptCount / 5              // attemptedDistinctCount


### PR DESCRIPTION
#66 

- 해당 readModel에서 첫 번째 시도 내용만 기록
- solve 이벤트를 수신하여, 새로운 사용자면 추가.
- `@BatchSize`로 메모리 오버헤드 X
- `SingleProblemReadModel.getSolvedStatus`에서 약간의 과부하가 있을 수 있다고 생각됨.
  - 현재 페이지 크기는 최대`20`개 로만 제한된 상황
  - 풀이자 수가 문제당 `10만명`이 되면,
  - 메모리엔 최대 20 * 100_000 즉, `2백만`개 로드  -> 메모리 과부하
    - 비교해보면,
      - 1) 쿼리 한번 -> 2백만개의 행 로드 
      - 2) 쿼리 최대 20번 -> 최대 20개의 행 
    - 임으로, 2)안 선택하자 
    - 메모리 과부하로 인한 서버 다운 방지 하지만 속도는 조금 느릴 수 있어. 

---
+) `IN`절로 조회된 문제들에 대해, 사용자의 풀이정보를 한번에 로드 ( 쿼리 한번으로 )


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Problem list now shows your per-problem first-try status (success, failure, or not attempted).
  * Paged problem listings are personalized to the logged-in user.
  * Attempt events are now persisted per user so statuses remain consistent across sessions.

* **Tests**
  * Updated and added tests covering per-user status display, personalized paging, and attempt-stat updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->