### PR TITLE
개별문제 조회 결과에 courseInfo 포함되도록 수정 

### DIFF
--- a/app/api/mathrank-course-api/build.gradle
+++ b/app/api/mathrank-course-api/build.gradle
@@ -4,5 +4,4 @@ dependencies {
 
     implementation project(':domain:mathrank-course-domain')
     implementation project(':app:api:mathrank-api-common')
-
 }

--- a/app/api/mathrank-course-api/build.gradle
+++ b/app/api/mathrank-course-api/build.gradle
@@ -1,0 +1,8 @@
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
+    implementation project(':domain:mathrank-course-domain')
+    implementation project(':app:api:mathrank-api-common')
+
+}

--- a/app/api/mathrank-course-api/src/main/java/kr/co/mathrank/app/api/course/CourseController.java
+++ b/app/api/mathrank-course-api/src/main/java/kr/co/mathrank/app/api/course/CourseController.java
@@ -1,4 +1,4 @@
-package kr.co.mathrank.app.api.problem;
+package kr.co.mathrank.app.api.course;
 
 import java.util.List;
 
@@ -10,8 +10,8 @@ import org.springframework.web.bind.annotation.RestController;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.co.mathrank.app.api.common.authentication.Authorization;
-import kr.co.mathrank.domain.problem.dto.CourseQueryResult;
-import kr.co.mathrank.domain.problem.service.CourseQueryService;
+import kr.co.mathrank.domain.course.dto.CourseQueryResult;
+import kr.co.mathrank.domain.course.service.CourseQueryService;
 import lombok.RequiredArgsConstructor;
 
 @Tag(name = "문제 과정 API", description = "문제 등록에서 사용되는 과정( 초/중/고, 대단원, 중단원, 소단원 )을 조회하기 위한 API 입니다.")

--- a/app/api/mathrank-course-inner-api/build.gradle
+++ b/app/api/mathrank-course-inner-api/build.gradle
@@ -4,5 +4,4 @@ dependencies {
 
     implementation project(':domain:mathrank-course-domain')
     implementation project(':app:api:mathrank-api-common')
-
 }

--- a/app/api/mathrank-course-inner-api/build.gradle
+++ b/app/api/mathrank-course-inner-api/build.gradle
@@ -1,0 +1,8 @@
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
+    implementation project(':domain:mathrank-course-domain')
+    implementation project(':app:api:mathrank-api-common')
+
+}

--- a/app/api/mathrank-course-inner-api/src/main/java/kr/co/mathrank/app/api/course/inner/CourseInnerController.java
+++ b/app/api/mathrank-course-inner-api/src/main/java/kr/co/mathrank/app/api/course/inner/CourseInnerController.java
@@ -1,0 +1,23 @@
+package kr.co.mathrank.app.api.course.inner;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import kr.co.mathrank.domain.course.dto.CourseQueryContainsParentsResult;
+import kr.co.mathrank.domain.course.service.CourseQueryService;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class CourseInnerController {
+	private final CourseQueryService courseQueryService;
+
+	@Operation(hidden = true)
+	@GetMapping("/api/inner/v1/course/parents")
+	public ResponseEntity<CourseQueryContainsParentsResult> queryAllParents(@RequestParam final String coursePath) {
+		return ResponseEntity.ok(courseQueryService.queryParents(coursePath));
+	}
+}

--- a/app/api/mathrank-problem-read-api/build.gradle
+++ b/app/api/mathrank-problem-read-api/build.gradle
@@ -7,5 +7,6 @@ dependencies {
     implementation project(':app:api:mathrank-api-common')
     implementation project(':domain:mathrank-problem-domain')
     implementation project(':client:internal:mathrank-member-client')
+    implementation project(':client:internal:mathrank-course-client')
     implementation project(':client:external:mathrank-school')
 }

--- a/app/api/mathrank-problem-read-api/src/main/java/kr/co/mathrank/app/api/problem/read/CourseResponse.java
+++ b/app/api/mathrank-problem-read-api/src/main/java/kr/co/mathrank/app/api/problem/read/CourseResponse.java
@@ -1,6 +1,6 @@
 package kr.co.mathrank.app.api.problem.read;
 
-import kr.co.mathrank.domain.problem.dto.CourseQueryResult;
+import kr.co.mathrank.client.internal.course.CourseQueryResult;
 
 public record CourseResponse(
 	String courseName,

--- a/app/api/mathrank-problem-read-api/src/main/java/kr/co/mathrank/app/api/problem/read/CourseTotalResponse.java
+++ b/app/api/mathrank-problem-read-api/src/main/java/kr/co/mathrank/app/api/problem/read/CourseTotalResponse.java
@@ -2,7 +2,7 @@ package kr.co.mathrank.app.api.problem.read;
 
 import java.util.List;
 
-import kr.co.mathrank.domain.problem.dto.CourseQueryContainsParentsResult;
+import kr.co.mathrank.client.internal.course.CourseQueryContainsParentsResult;
 
 public record CourseTotalResponse(
 	CourseResponse target,

--- a/app/api/mathrank-problem-read-api/src/main/java/kr/co/mathrank/app/api/problem/read/ProblemReadController.java
+++ b/app/api/mathrank-problem-read-api/src/main/java/kr/co/mathrank/app/api/problem/read/ProblemReadController.java
@@ -7,7 +7,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -19,13 +18,13 @@ import kr.co.mathrank.app.api.common.authentication.MemberPrincipal;
 import kr.co.mathrank.client.external.school.RequestType;
 import kr.co.mathrank.client.external.school.SchoolClient;
 import kr.co.mathrank.client.external.school.SchoolInfo;
+import kr.co.mathrank.client.internal.course.CourseClient;
+import kr.co.mathrank.client.internal.course.CourseQueryContainsParentsResult;
 import kr.co.mathrank.client.internal.member.MemberClient;
 import kr.co.mathrank.client.internal.member.MemberInfo;
-import kr.co.mathrank.domain.problem.dto.CourseQueryContainsParentsResult;
 import kr.co.mathrank.domain.problem.dto.ProblemQueryCommand;
 import kr.co.mathrank.domain.problem.dto.ProblemQueryPageResult;
 import kr.co.mathrank.domain.problem.dto.ProblemQueryResult;
-import kr.co.mathrank.domain.problem.service.CourseQueryService;
 import kr.co.mathrank.domain.problem.service.ProblemQueryService;
 import lombok.RequiredArgsConstructor;
 
@@ -34,7 +33,7 @@ import lombok.RequiredArgsConstructor;
 @Tag(name = "문제 API")
 public class ProblemReadController {
 	private final ProblemQueryService problemQueryService;
-	private final CourseQueryService courseQueryService;
+	private final CourseClient courseClient;
 	private final MemberClient memberClient;
 	private final SchoolClient schoolClient;
 
@@ -75,7 +74,7 @@ public class ProblemReadController {
 		final MemberInfo info = memberClient.getMemberInfo(problem.memberId());
 		final SchoolInfo schoolInfo = schoolClient.getSchool(RequestType.JSON.getType(), problem.schoolCode())
 			.orElse(SchoolInfo.none());
-		final CourseQueryContainsParentsResult result = courseQueryService.queryParents(problem.path());
+		final CourseQueryContainsParentsResult result = courseClient.getParentCourses(problem.path());
 		return ProblemResponse.from(problem, info, schoolInfo, result);
 	}
 }

--- a/app/api/mathrank-problem-read-api/src/main/java/kr/co/mathrank/app/api/problem/read/ProblemResponse.java
+++ b/app/api/mathrank-problem-read-api/src/main/java/kr/co/mathrank/app/api/problem/read/ProblemResponse.java
@@ -4,10 +4,10 @@ import java.time.LocalDateTime;
 import java.util.Set;
 
 import kr.co.mathrank.client.external.school.SchoolInfo;
+import kr.co.mathrank.client.internal.course.CourseQueryContainsParentsResult;
 import kr.co.mathrank.client.internal.member.MemberInfo;
 import kr.co.mathrank.domain.problem.core.AnswerType;
 import kr.co.mathrank.domain.problem.core.Difficulty;
-import kr.co.mathrank.domain.problem.dto.CourseQueryContainsParentsResult;
 import kr.co.mathrank.domain.problem.dto.ProblemQueryResult;
 
 public record ProblemResponse(

--- a/app/api/mathrank-problem-single-read-api/build.gradle
+++ b/app/api/mathrank-problem-single-read-api/build.gradle
@@ -7,4 +7,5 @@ dependencies {
     implementation project(':domain:mathrank-problem-core-domain')
 
     implementation project(':app:api:mathrank-api-common')
+    implementation project(':client:internal:mathrank-course-client')
 }

--- a/app/api/mathrank-problem-single-read-api/src/main/java/kr/co/mathrank/app/api/problem/single/read/SingleProblemQueryPageResponse.java
+++ b/app/api/mathrank-problem-single-read-api/src/main/java/kr/co/mathrank/app/api/problem/single/read/SingleProblemQueryPageResponse.java
@@ -1,0 +1,24 @@
+package kr.co.mathrank.app.api.problem.single.read;
+
+import java.util.List;
+
+public record SingleProblemQueryPageResponse(
+	List<SingleProblemReadModelResponse> queryResults,
+	Integer currentPageNumber,
+	Integer currentPageSize,
+	List<Integer> possibleNextPageNumbers
+) {
+	public static SingleProblemQueryPageResponse from(
+		final List<SingleProblemReadModelResponse> responses,
+		final Integer currentPageNumber,
+		final Integer currentPageSize,
+		final List<Integer> possibleNextPageNumbers
+	) {
+		return new SingleProblemQueryPageResponse(
+			responses,
+			currentPageNumber,
+			currentPageSize,
+			possibleNextPageNumbers
+		);
+	}
+}

--- a/app/api/mathrank-problem-single-read-api/src/main/java/kr/co/mathrank/app/api/problem/single/read/SingleProblemReadModelResponse.java
+++ b/app/api/mathrank-problem-single-read-api/src/main/java/kr/co/mathrank/app/api/problem/single/read/SingleProblemReadModelResponse.java
@@ -12,7 +12,7 @@ public record SingleProblemReadModelResponse(
 	String singleProblemName,
 	String problemImage,
 
-	CourseQueryContainsParentsResult result,
+	CourseQueryContainsParentsResult courseInfo,
 
 	AnswerType answerType,
 	Difficulty difficulty,
@@ -21,14 +21,14 @@ public record SingleProblemReadModelResponse(
 	Long attemptedUserDistinctCount, // 해당 문제를 풀려고 한 사용자 수
 	Double accuracy // 정답률
 ) {
-	public static SingleProblemReadModelResponse of(SingleProblemReadModelResult result, CourseQueryContainsParentsResult courseQueryContainsParentsResult) {
+	public static SingleProblemReadModelResponse of(SingleProblemReadModelResult result, CourseQueryContainsParentsResult courseInfo) {
 		return new SingleProblemReadModelResponse(
 			result.id(),
 			result.successAtFirstTry(),
 			result.problemId(),
 			result.singleProblemName(),
 			result.problemImage(),
-			courseQueryContainsParentsResult,
+			courseInfo,
 			result.answerType(),
 			result.difficulty(),
 			result.firstTrySuccessCount(),

--- a/app/api/mathrank-problem-single-read-api/src/main/java/kr/co/mathrank/app/api/problem/single/read/SingleProblemReadModelResponse.java
+++ b/app/api/mathrank-problem-single-read-api/src/main/java/kr/co/mathrank/app/api/problem/single/read/SingleProblemReadModelResponse.java
@@ -1,0 +1,40 @@
+package kr.co.mathrank.app.api.problem.single.read;
+
+import kr.co.mathrank.client.internal.course.CourseQueryContainsParentsResult;
+import kr.co.mathrank.domain.problem.core.AnswerType;
+import kr.co.mathrank.domain.problem.core.Difficulty;
+import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemReadModelResult;
+
+public record SingleProblemReadModelResponse(
+	Long id, // single problem id
+	Boolean successAtFirstTry, // null: 푼적 없음, true: 성공해썽, false: 실패해썽
+	Long problemId, // problem id
+	String singleProblemName,
+	String problemImage,
+
+	CourseQueryContainsParentsResult result,
+
+	AnswerType answerType,
+	Difficulty difficulty,
+	Long firstTrySuccessCount, // 첫번째 시도에서 성공한 횟수
+	Long totalAttemptedCount, // 문제를 풀려고 시도한 총 횟수
+	Long attemptedUserDistinctCount, // 해당 문제를 풀려고 한 사용자 수
+	Double accuracy // 정답률
+) {
+	public static SingleProblemReadModelResponse of(SingleProblemReadModelResult result, CourseQueryContainsParentsResult courseQueryContainsParentsResult) {
+		return new SingleProblemReadModelResponse(
+			result.id(),
+			result.successAtFirstTry(),
+			result.problemId(),
+			result.singleProblemName(),
+			result.problemImage(),
+			courseQueryContainsParentsResult,
+			result.answerType(),
+			result.difficulty(),
+			result.firstTrySuccessCount(),
+			result.totalAttemptedCount(),
+			result.attemptedUserDistinctCount(),
+			result.accuracy()
+		);
+	}
+}

--- a/app/api/monolith-api/build.gradle
+++ b/app/api/monolith-api/build.gradle
@@ -2,6 +2,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
 
     implementation project(':app:api:mathrank-auth-api')
+    implementation project(':app:api:mathrank-course-api')
     implementation project(':app:api:mathrank-problem-assessment-api')
     implementation project(':app:api:mathrank-healthcheck-api')
     implementation project(':app:api:mathrank-image-api')

--- a/app/api/monolith-api/build.gradle
+++ b/app/api/monolith-api/build.gradle
@@ -3,6 +3,7 @@ dependencies {
 
     implementation project(':app:api:mathrank-auth-api')
     implementation project(':app:api:mathrank-course-api')
+    implementation project(':app:api:mathrank-course-inner-api')
     implementation project(':app:api:mathrank-problem-assessment-api')
     implementation project(':app:api:mathrank-healthcheck-api')
     implementation project(':app:api:mathrank-image-api')

--- a/app/api/monolith-api/src/main/resources/application.properties
+++ b/app/api/monolith-api/src/main/resources/application.properties
@@ -19,3 +19,6 @@ cors.mode=${CORS_MODE}
 
 client.problem.host=http://localhost
 client.problem.port=8080
+
+client.course.host=http://localhost
+client.course.port=8080

--- a/app/init/mathrank-problem-init/build.gradle
+++ b/app/init/mathrank-problem-init/build.gradle
@@ -3,5 +3,5 @@ dependencies {
 
     implementation 'org.apache.poi:poi-ooxml:5.2.3'
 
-    implementation project(':domain:mathrank-problem-domain')
+    implementation project(':domain:mathrank-course-domain')
 }

--- a/app/init/mathrank-problem-init/src/main/java/kr/co/mathrank/app/init/problem/CourseInitializer.java
+++ b/app/init/mathrank-problem-init/src/main/java/kr/co/mathrank/app/init/problem/CourseInitializer.java
@@ -13,11 +13,11 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Component;
 
-import kr.co.mathrank.domain.problem.dto.CourseRegisterCommand;
-import kr.co.mathrank.domain.problem.entity.Course;
-import kr.co.mathrank.domain.problem.entity.Path;
-import kr.co.mathrank.domain.problem.repository.CourseRepository;
-import kr.co.mathrank.domain.problem.service.CourseService;
+import kr.co.mathrank.domain.course.dto.CourseRegisterCommand;
+import kr.co.mathrank.domain.course.entity.Course;
+import kr.co.mathrank.domain.course.entity.Path;
+import kr.co.mathrank.domain.course.repository.CourseRepository;
+import kr.co.mathrank.domain.course.service.CourseService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 

--- a/client/internal/mathrank-course-client/build.gradle
+++ b/client/internal/mathrank-course-client/build.gradle
@@ -1,0 +1,4 @@
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+}

--- a/client/internal/mathrank-course-client/src/main/java/kr/co/mathrank/client/internal/course/CourseClient.java
+++ b/client/internal/mathrank-course-client/src/main/java/kr/co/mathrank/client/internal/course/CourseClient.java
@@ -40,10 +40,6 @@ public class CourseClient {
 			.body(CourseQueryContainsParentsResult.class);
 	}
 
-	private String getUrlFormat(final String host, final Integer port) {
-		return URL_FORMAT.formatted(host, port);
-	};
-
 	@Getter
 	@Configuration
 	@ConfigurationProperties("client.course")

--- a/client/internal/mathrank-course-client/src/main/java/kr/co/mathrank/client/internal/course/CourseClient.java
+++ b/client/internal/mathrank-course-client/src/main/java/kr/co/mathrank/client/internal/course/CourseClient.java
@@ -10,7 +10,10 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Component
 public class CourseClient {
 	private static final String URL_FORMAT = "%s:%s";
@@ -18,12 +21,16 @@ public class CourseClient {
 	private final RestClient restClient;
 
 	CourseClient(final CourseClientProperties properties) {
+		final String baseURL = URL_FORMAT.formatted(properties.getHost(), properties.getPort());
+		log.info("[CourseClient.new] init : {}", properties);
+		log.info("[CourseClient.new] init : {}", baseURL);
 		this.restClient = RestClient.builder()
-			.baseUrl(getUrlFormat(properties.host, properties.port))
+			.baseUrl(baseURL)
 			.build();
 	}
 
 	public CourseQueryContainsParentsResult getParentCourses(final String coursePath) {
+		log.info("[CourseClient.getParentCourses]: called - coursePath: {}", coursePath);
 		return restClient.get()
 			.uri(uriBuilder -> uriBuilder
 				.path("/api/inner/v1/course/parents")
@@ -43,6 +50,7 @@ public class CourseClient {
 	@NoArgsConstructor
 	@Setter
 	@Validated
+	@ToString
 	static class CourseClientProperties {
 		@NotNull
 		private String host;

--- a/client/internal/mathrank-course-client/src/main/java/kr/co/mathrank/client/internal/course/CourseClient.java
+++ b/client/internal/mathrank-course-client/src/main/java/kr/co/mathrank/client/internal/course/CourseClient.java
@@ -1,0 +1,52 @@
+package kr.co.mathrank.client.internal.course;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.client.RestClient;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Component
+public class CourseClient {
+	private static final String URL_FORMAT = "%s:%s";
+
+	private final RestClient restClient;
+
+	CourseClient(final CourseClientProperties properties) {
+		this.restClient = RestClient.builder()
+			.baseUrl(getUrlFormat(properties.host, properties.port))
+			.build();
+	}
+
+	public CourseQueryContainsParentsResult getParentCourses(final String coursePath) {
+		return restClient.get()
+			.uri(uriBuilder -> uriBuilder
+				.path("/api/inner/v1/course/parents")
+				.queryParam("coursePath", coursePath)
+				.build())
+			.retrieve()
+			.body(CourseQueryContainsParentsResult.class);
+	}
+
+	private String getUrlFormat(final String host, final Integer port) {
+		return URL_FORMAT.formatted(host, port);
+	};
+
+	@Getter
+	@Configuration
+	@ConfigurationProperties("client.course")
+	@NoArgsConstructor
+	@Setter
+	@Validated
+	static class CourseClientProperties {
+		@NotNull
+		private String host;
+		@NotNull
+		private Integer port;
+	}
+}

--- a/client/internal/mathrank-course-client/src/main/java/kr/co/mathrank/client/internal/course/CourseClient.java
+++ b/client/internal/mathrank-course-client/src/main/java/kr/co/mathrank/client/internal/course/CourseClient.java
@@ -22,7 +22,6 @@ public class CourseClient {
 
 	CourseClient(final CourseClientProperties properties) {
 		final String baseURL = URL_FORMAT.formatted(properties.getHost(), properties.getPort());
-		log.info("[CourseClient.new] init : {}", properties);
 		log.info("[CourseClient.new] init : {}", baseURL);
 		this.restClient = RestClient.builder()
 			.baseUrl(baseURL)

--- a/client/internal/mathrank-course-client/src/main/java/kr/co/mathrank/client/internal/course/CourseQueryContainsParentsResult.java
+++ b/client/internal/mathrank-course-client/src/main/java/kr/co/mathrank/client/internal/course/CourseQueryContainsParentsResult.java
@@ -1,0 +1,9 @@
+package kr.co.mathrank.client.internal.course;
+
+import java.util.List;
+
+public record CourseQueryContainsParentsResult(
+	CourseQueryResult target,
+	List<CourseQueryResult> parents
+) {
+}

--- a/client/internal/mathrank-course-client/src/main/java/kr/co/mathrank/client/internal/course/CourseQueryResult.java
+++ b/client/internal/mathrank-course-client/src/main/java/kr/co/mathrank/client/internal/course/CourseQueryResult.java
@@ -1,0 +1,7 @@
+package kr.co.mathrank.client.internal.course;
+
+public record CourseQueryResult(
+	String coursePath,
+	String courseName
+) {
+}

--- a/domain/mathrank-course-domain/build.gradle
+++ b/domain/mathrank-course-domain/build.gradle
@@ -1,0 +1,7 @@
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    implementation project(':common:mathrank-exception')
+    testRuntimeOnly 'com.h2database:h2'
+}

--- a/domain/mathrank-course-domain/src/main/java/kr/co/mathrank/domain/course/dto/CourseQueryContainsParentsResult.java
+++ b/domain/mathrank-course-domain/src/main/java/kr/co/mathrank/domain/course/dto/CourseQueryContainsParentsResult.java
@@ -1,4 +1,4 @@
-package kr.co.mathrank.domain.problem.dto;
+package kr.co.mathrank.domain.course.dto;
 
 import java.util.List;
 

--- a/domain/mathrank-course-domain/src/main/java/kr/co/mathrank/domain/course/dto/CourseQueryResult.java
+++ b/domain/mathrank-course-domain/src/main/java/kr/co/mathrank/domain/course/dto/CourseQueryResult.java
@@ -1,6 +1,6 @@
-package kr.co.mathrank.domain.problem.dto;
+package kr.co.mathrank.domain.course.dto;
 
-import kr.co.mathrank.domain.problem.entity.Course;
+import kr.co.mathrank.domain.course.entity.Course;
 
 public record CourseQueryResult(
 	String coursePath,

--- a/domain/mathrank-course-domain/src/main/java/kr/co/mathrank/domain/course/dto/CourseQueryResults.java
+++ b/domain/mathrank-course-domain/src/main/java/kr/co/mathrank/domain/course/dto/CourseQueryResults.java
@@ -1,4 +1,4 @@
-package kr.co.mathrank.domain.problem.dto;
+package kr.co.mathrank.domain.course.dto;
 
 import java.util.List;
 

--- a/domain/mathrank-course-domain/src/main/java/kr/co/mathrank/domain/course/dto/CourseRegisterCommand.java
+++ b/domain/mathrank-course-domain/src/main/java/kr/co/mathrank/domain/course/dto/CourseRegisterCommand.java
@@ -1,4 +1,4 @@
-package kr.co.mathrank.domain.problem.dto;
+package kr.co.mathrank.domain.course.dto;
 
 import jakarta.validation.constraints.NotNull;
 

--- a/domain/mathrank-course-domain/src/main/java/kr/co/mathrank/domain/course/entity/Course.java
+++ b/domain/mathrank-course-domain/src/main/java/kr/co/mathrank/domain/course/entity/Course.java
@@ -1,28 +1,19 @@
-package kr.co.mathrank.domain.problem.entity;
-
-import java.util.ArrayList;
-import java.util.List;
+package kr.co.mathrank.domain.course.entity;
 
 import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
-import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Entity
 @Getter
-@ToString(exclude = "problems")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Course {
 	@EmbeddedId
 	private Path path = new Path();
 
 	private String courseName;
-
-	@OneToMany(mappedBy = "course")
-	private final List<Problem> problems = new ArrayList<>();
 
 	public static Course of(final String courseName, final Path path) {
 		final Course course = new Course();

--- a/domain/mathrank-course-domain/src/main/java/kr/co/mathrank/domain/course/entity/Path.java
+++ b/domain/mathrank-course-domain/src/main/java/kr/co/mathrank/domain/course/entity/Path.java
@@ -1,4 +1,4 @@
-package kr.co.mathrank.domain.problem.entity;
+package kr.co.mathrank.domain.course.entity;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -124,3 +124,4 @@ public class Path {
 		return SEQUENCE.indexOf(target);
 	}
 }
+

--- a/domain/mathrank-course-domain/src/main/java/kr/co/mathrank/domain/course/exception/CannotFoundCourseException.java
+++ b/domain/mathrank-course-domain/src/main/java/kr/co/mathrank/domain/course/exception/CannotFoundCourseException.java
@@ -1,4 +1,4 @@
-package kr.co.mathrank.domain.problem.exception;
+package kr.co.mathrank.domain.course.exception;
 
 public class CannotFoundCourseException extends CourseException {
 	private static final String FORMAT = "존재하지 않는 과정: %s";

--- a/domain/mathrank-course-domain/src/main/java/kr/co/mathrank/domain/course/exception/CourseException.java
+++ b/domain/mathrank-course-domain/src/main/java/kr/co/mathrank/domain/course/exception/CourseException.java
@@ -1,4 +1,4 @@
-package kr.co.mathrank.domain.problem.exception;
+package kr.co.mathrank.domain.course.exception;
 
 import kr.co.mathrank.common.exception.MathRankException;
 

--- a/domain/mathrank-course-domain/src/main/java/kr/co/mathrank/domain/course/repository/CourseRepository.java
+++ b/domain/mathrank-course-domain/src/main/java/kr/co/mathrank/domain/course/repository/CourseRepository.java
@@ -1,4 +1,4 @@
-package kr.co.mathrank.domain.problem.repository;
+package kr.co.mathrank.domain.course.repository;
 
 import java.util.List;
 import java.util.Optional;
@@ -8,8 +8,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import kr.co.mathrank.domain.problem.entity.Course;
-import kr.co.mathrank.domain.problem.entity.Path;
+import kr.co.mathrank.domain.course.entity.Course;
+import kr.co.mathrank.domain.course.entity.Path;
 
 public interface CourseRepository extends JpaRepository<Course, Path> {
 	@Query("SELECT c FROM Course c WHERE c.path.path LIKE CONCAT(:path, '%')")
@@ -24,3 +24,4 @@ public interface CourseRepository extends JpaRepository<Course, Path> {
 
 	List<Course> findAllByPathIn(List<Path> paths);
 }
+

--- a/domain/mathrank-course-domain/src/main/java/kr/co/mathrank/domain/course/service/CourseQueryService.java
+++ b/domain/mathrank-course-domain/src/main/java/kr/co/mathrank/domain/course/service/CourseQueryService.java
@@ -1,4 +1,4 @@
-package kr.co.mathrank.domain.problem.service;
+package kr.co.mathrank.domain.course.service;
 
 import java.util.List;
 
@@ -6,11 +6,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.validation.annotation.Validated;
 
 import jakarta.validation.constraints.NotNull;
-import kr.co.mathrank.domain.problem.dto.CourseQueryContainsParentsResult;
-import kr.co.mathrank.domain.problem.dto.CourseQueryResult;
-import kr.co.mathrank.domain.problem.dto.CourseQueryResults;
-import kr.co.mathrank.domain.problem.entity.Path;
-import kr.co.mathrank.domain.problem.repository.CourseRepository;
+import kr.co.mathrank.domain.course.dto.CourseQueryContainsParentsResult;
+import kr.co.mathrank.domain.course.dto.CourseQueryResult;
+import kr.co.mathrank.domain.course.dto.CourseQueryResults;
+import kr.co.mathrank.domain.course.entity.Path;
+import kr.co.mathrank.domain.course.repository.CourseRepository;
 import lombok.RequiredArgsConstructor;
 
 @Service

--- a/domain/mathrank-course-domain/src/main/java/kr/co/mathrank/domain/course/service/CourseService.java
+++ b/domain/mathrank-course-domain/src/main/java/kr/co/mathrank/domain/course/service/CourseService.java
@@ -1,4 +1,4 @@
-package kr.co.mathrank.domain.problem.service;
+package kr.co.mathrank.domain.course.service;
 
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -8,11 +8,11 @@ import org.springframework.validation.annotation.Validated;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import kr.co.mathrank.domain.problem.dto.CourseRegisterCommand;
-import kr.co.mathrank.domain.problem.entity.Course;
-import kr.co.mathrank.domain.problem.entity.Path;
-import kr.co.mathrank.domain.problem.exception.CannotFoundCourseException;
-import kr.co.mathrank.domain.problem.repository.CourseRepository;
+import kr.co.mathrank.domain.course.dto.CourseRegisterCommand;
+import kr.co.mathrank.domain.course.entity.Course;
+import kr.co.mathrank.domain.course.entity.Path;
+import kr.co.mathrank.domain.course.exception.CannotFoundCourseException;
+import kr.co.mathrank.domain.course.repository.CourseRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 

--- a/domain/mathrank-course-domain/src/test/java/kr/co/mathrank/CourseDomainApplication.java
+++ b/domain/mathrank-course-domain/src/test/java/kr/co/mathrank/CourseDomainApplication.java
@@ -1,0 +1,7 @@
+package kr.co.mathrank;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class CourseDomainApplication {
+}

--- a/domain/mathrank-course-domain/src/test/java/kr/co/mathrank/domain/course/entity/PathTest.java
+++ b/domain/mathrank-course-domain/src/test/java/kr/co/mathrank/domain/course/entity/PathTest.java
@@ -1,4 +1,4 @@
-package kr.co.mathrank.domain.problem.entity;
+package kr.co.mathrank.domain.course.entity;
 
 import java.util.List;
 

--- a/domain/mathrank-course-domain/src/test/java/kr/co/mathrank/domain/course/repository/CourseRepositoryTest.java
+++ b/domain/mathrank-course-domain/src/test/java/kr/co/mathrank/domain/course/repository/CourseRepositoryTest.java
@@ -1,4 +1,4 @@
-package kr.co.mathrank.domain.problem.repository;
+package kr.co.mathrank.domain.course.repository;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -8,8 +8,8 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.transaction.annotation.Transactional;
 
-import kr.co.mathrank.domain.problem.entity.Course;
-import kr.co.mathrank.domain.problem.entity.Path;
+import kr.co.mathrank.domain.course.entity.Course;
+import kr.co.mathrank.domain.course.entity.Path;
 
 @SpringBootTest
 @Transactional

--- a/domain/mathrank-course-domain/src/test/java/kr/co/mathrank/domain/course/service/CourseQueryServiceTest.java
+++ b/domain/mathrank-course-domain/src/test/java/kr/co/mathrank/domain/course/service/CourseQueryServiceTest.java
@@ -1,4 +1,4 @@
-package kr.co.mathrank.domain.problem.service;
+package kr.co.mathrank.domain.course.service;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -6,10 +6,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
-import kr.co.mathrank.domain.problem.dto.CourseQueryContainsParentsResult;
-import kr.co.mathrank.domain.problem.entity.Course;
-import kr.co.mathrank.domain.problem.entity.Path;
-import kr.co.mathrank.domain.problem.repository.CourseRepository;
+import kr.co.mathrank.domain.course.dto.CourseQueryContainsParentsResult;
+import kr.co.mathrank.domain.course.entity.Course;
+import kr.co.mathrank.domain.course.entity.Path;
+import kr.co.mathrank.domain.course.repository.CourseRepository;
 
 @SpringBootTest
 @Transactional

--- a/domain/mathrank-course-domain/src/test/java/kr/co/mathrank/domain/course/service/CourseServiceTest.java
+++ b/domain/mathrank-course-domain/src/test/java/kr/co/mathrank/domain/course/service/CourseServiceTest.java
@@ -1,4 +1,4 @@
-package kr.co.mathrank.domain.problem.service;
+package kr.co.mathrank.domain.course.service;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -6,10 +6,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
-import kr.co.mathrank.domain.problem.dto.CourseRegisterCommand;
-import kr.co.mathrank.domain.problem.entity.Path;
-import kr.co.mathrank.domain.problem.exception.CannotFoundCourseException;
-import kr.co.mathrank.domain.problem.repository.CourseRepository;
+import kr.co.mathrank.domain.course.dto.CourseRegisterCommand;
+import kr.co.mathrank.domain.course.entity.Path;
+import kr.co.mathrank.domain.course.exception.CannotFoundCourseException;
+import kr.co.mathrank.domain.course.repository.CourseRepository;
 
 @SpringBootTest
 @Transactional

--- a/domain/mathrank-problem-domain/src/main/java/kr/co/mathrank/domain/problem/dto/ProblemQueryResult.java
+++ b/domain/mathrank-problem-domain/src/main/java/kr/co/mathrank/domain/problem/dto/ProblemQueryResult.java
@@ -28,7 +28,7 @@ public record ProblemQueryResult(
 			problem.getMemberId(),
 			problem.getProblemImage(),
 			// null 대비
-			problem.getCourse() == null ? "" : problem.getCourse().getPath().getPath(),
+			String.valueOf(problem.getCoursePath()),
 			problem.getDifficulty(),
 			problem.getType(),
 			problem.getSchoolCode(),

--- a/domain/mathrank-problem-domain/src/main/java/kr/co/mathrank/domain/problem/entity/Problem.java
+++ b/domain/mathrank-problem-domain/src/main/java/kr/co/mathrank/domain/problem/entity/Problem.java
@@ -60,8 +60,7 @@ public class Problem implements Persistable<Long> {
 	@Enumerated(EnumType.STRING)
 	private AnswerType type;
 
-	@ManyToOne(fetch = FetchType.LAZY)
-	private Course course;
+	private String coursePath;
 
 	private String schoolCode;
 
@@ -84,7 +83,7 @@ public class Problem implements Persistable<Long> {
 	private String memo;
 
 	public static Problem of(final Long id, final Long memberId, final String problemImage, final Difficulty difficulty,
-		final AnswerType type, final Course course, final String schoolCode,
+		final AnswerType type, final String coursePath, final String schoolCode,
 		final String solutionVideoLink, final String solutionImage, final Integer year, final String location, final String memo) {
 
 		final Problem problem = new Problem();
@@ -93,7 +92,7 @@ public class Problem implements Persistable<Long> {
 		problem.problemImage = problemImage;
 		problem.difficulty = difficulty;
 		problem.type = type;
-		problem.course = course;
+		problem.coursePath = coursePath;
 		problem.schoolCode = schoolCode;
 		problem.solutionVideoLink = solutionVideoLink;
 		problem.solutionImage = solutionImage;

--- a/domain/mathrank-problem-domain/src/main/java/kr/co/mathrank/domain/problem/repository/ProblemQueryRepositoryImpl.java
+++ b/domain/mathrank-problem-domain/src/main/java/kr/co/mathrank/domain/problem/repository/ProblemQueryRepositoryImpl.java
@@ -103,7 +103,7 @@ class ProblemQueryRepositoryImpl implements ProblemQueryRepository {
 		if (path == null) {
 			return null;
 		}
-		return QProblem.problem.course.path.path.startsWith(path);
+		return QProblem.problem.coursePath.startsWith(path);
 	}
 
 	private BooleanExpression solutionVideoLinkExist(final Boolean solutionVideoLinkExist) {

--- a/domain/mathrank-problem-domain/src/test/java/kr/co/mathrank/domain/problem/entity/ProblemTest.java
+++ b/domain/mathrank-problem-domain/src/test/java/kr/co/mathrank/domain/problem/entity/ProblemTest.java
@@ -18,7 +18,7 @@ class ProblemTest {
 
 	@Test
 	void 영속화될때_새로운_엔티티로_판단한다() {
-		final Problem problem = Problem.of(1L, 2L, "문제.jpeg", Difficulty.KILLER, AnswerType.MULTIPLE_CHOICE, Course.of("test", new Path()), "testCode", null, null, 1001, null, null);
+		final Problem problem = Problem.of(1L, 2L, "문제.jpeg", Difficulty.KILLER, AnswerType.MULTIPLE_CHOICE, "testPath", "testCode", null, null, 1001, null, null);
 		final Problem savedProblem = problemRepository.save(problem);
 
 		// save 시, merge 면 새로운 엔티티를 반환한다.

--- a/domain/mathrank-problem-domain/src/test/java/kr/co/mathrank/domain/problem/repository/ProblemRepositoryTest.java
+++ b/domain/mathrank-problem-domain/src/test/java/kr/co/mathrank/domain/problem/repository/ProblemRepositoryTest.java
@@ -16,8 +16,6 @@ import jakarta.persistence.PersistenceContext;
 import kr.co.mathrank.domain.problem.core.AnswerType;
 import kr.co.mathrank.domain.problem.core.Difficulty;
 import kr.co.mathrank.domain.problem.entity.Answer;
-import kr.co.mathrank.domain.problem.entity.Course;
-import kr.co.mathrank.domain.problem.entity.Path;
 import kr.co.mathrank.domain.problem.entity.Problem;
 
 @SpringBootTest
@@ -25,24 +23,19 @@ import kr.co.mathrank.domain.problem.entity.Problem;
 class ProblemRepositoryTest {
 	@Autowired
 	private ProblemRepository problemRepository;
-	@Autowired
-	private CourseRepository courseRepository;
 	@PersistenceContext
 	private EntityManager entityManager;
 
 	@Test
 	void 본인_문제_조회_테스트() {
-		final Path path = new Path();
-		final Course course = Course.of("test", path);
-		courseRepository.save(course);
 		entityManager.flush();
 		entityManager.clear();
 
 		// 사용자 1의 문제
-		final Problem owner1 = Problem.of((long) 1, 2L, "문제.jpeg", Difficulty.KILLER, AnswerType.MULTIPLE_CHOICE, course, "testCode", null, null,
+		final Problem owner1 = Problem.of((long) 1, 2L, "문제.jpeg", Difficulty.KILLER, AnswerType.MULTIPLE_CHOICE, "testPath", "testCode", null, null,
 			1001, null, null);
 		// 사용자 2의 문제
-		final Problem owner2 = Problem.of((long) 2, 1L, "문제.jpeg", Difficulty.KILLER, AnswerType.MULTIPLE_CHOICE, course, "testCode", null, null, 1001, null, null);
+		final Problem owner2 = Problem.of((long) 2, 1L, "문제.jpeg", Difficulty.KILLER, AnswerType.MULTIPLE_CHOICE, "testPath", "testCode", null, null, 1001, null, null);
 
 		problemRepository.save(owner1);
 		problemRepository.save(owner2);
@@ -55,16 +48,13 @@ class ProblemRepositoryTest {
 
 	@Test
 	void 문제ID_로_조회된다() {
-		final Path path = new Path();
-		final Course course = Course.of("test", path);
-		courseRepository.save(course);
 		entityManager.flush();
 		entityManager.clear();
 
 		final Long problemId = 1021923L;
 
 		// 사용자 1의 문제
-		final Problem problem = Problem.of(problemId, 2L, "문제.jpeg", Difficulty.KILLER, AnswerType.MULTIPLE_CHOICE, course, "testCode", null, null,
+		final Problem problem = Problem.of(problemId, 2L, "문제.jpeg", Difficulty.KILLER, AnswerType.MULTIPLE_CHOICE, "testPath", "testCode", null, null,
 			1001, null, null);
 
 		problemRepository.save(problem);
@@ -77,14 +67,11 @@ class ProblemRepositoryTest {
 
 	@Test
 	void 조건_없을때_모두_조회한다() {
-		final Path path = new Path();
-		final Course course = Course.of("test", path);
-		courseRepository.save(course);
 		entityManager.flush();
 		entityManager.clear();
 
-		final Problem problem1 = Problem.of(1L, 2L, "문제.jpeg", Difficulty.KILLER, AnswerType.MULTIPLE_CHOICE, course, "testCode", null, null, 1001, null, null);
-		final Problem problem2 = Problem.of(2L, 2L, "문제.jpeg", Difficulty.KILLER, AnswerType.MULTIPLE_CHOICE, course, "testCode", null, null, 1001, null, null);
+		final Problem problem1 = Problem.of(1L, 2L, "문제.jpeg", Difficulty.KILLER, AnswerType.MULTIPLE_CHOICE, "testPath", "testCode", null, null, 1001, null, null);
+		final Problem problem2 = Problem.of(2L, 2L, "문제.jpeg", Difficulty.KILLER, AnswerType.MULTIPLE_CHOICE, "testPath", "testCode", null, null, 1001, null, null);
 
 		problemRepository.save(problem1);
 		problemRepository.save(problem2);
@@ -97,17 +84,14 @@ class ProblemRepositoryTest {
 
 	@Test
 	void 단일_조건_으로_조회된다() {
-		final Path path = new Path();
-		final Course course = Course.of("test", path);
-		courseRepository.save(course);
 		entityManager.flush();
 		entityManager.clear();
 
 		// level 4
-		final Problem problem1 = Problem.of(1L, 2L, "문제.jpeg", Difficulty.HIGH, AnswerType.MULTIPLE_CHOICE, course, "testCode", null, null, 1001, null, null);
+		final Problem problem1 = Problem.of(1L, 2L, "문제.jpeg", Difficulty.HIGH, AnswerType.MULTIPLE_CHOICE, "testPath", "testCode", null, null, 1001, null, null);
 
 		// level 5
-		final Problem problem2 = Problem.of(2L, 2L, "문제.jpeg", Difficulty.KILLER, AnswerType.MULTIPLE_CHOICE, course, "testCode", null, null, 1001, null, null);
+		final Problem problem2 = Problem.of(2L, 2L, "문제.jpeg", Difficulty.KILLER, AnswerType.MULTIPLE_CHOICE, "testPath", "testCode", null, null, 1001, null, null);
 
 		problemRepository.save(problem1);
 		problemRepository.save(problem2);
@@ -120,35 +104,29 @@ class ProblemRepositoryTest {
 
 	@Test
 	void 여러조건으로_조회된다() {
-		final Path path = new Path();
-		final Course course = Course.of("test", path);
-		courseRepository.save(course);
 		entityManager.flush();
 		entityManager.clear();
 
-		final Problem problem1 = Problem.of(1L, 1L, "문제.jpeg", Difficulty.KILLER, AnswerType.MULTIPLE_CHOICE, course, "testCode", null, null, 1001, null, null);
-		final Problem problem2 = Problem.of(2L, 3L, "문제.jpeg", Difficulty.KILLER, AnswerType.MULTIPLE_CHOICE, course, "testCode", null, null, 1001, null, null);
+		final Problem problem1 = Problem.of(1L, 1L, "문제.jpeg", Difficulty.KILLER, AnswerType.MULTIPLE_CHOICE, "testPath", "testCode", null, null, 1001, null, null);
+		final Problem problem2 = Problem.of(2L, 3L, "문제.jpeg", Difficulty.KILLER, AnswerType.MULTIPLE_CHOICE, "testPath", "testCode", null, null, 1001, null, null);
 
 		problemRepository.save(problem1);
 		problemRepository.save(problem2);
 
 		final List<Problem> problems = problemRepository.query(1L, null, Difficulty.KILLER, Difficulty.KILLER,
 			AnswerType.MULTIPLE_CHOICE,
-			"aa", null, 1001, null, 10, 1);
+			"testPath", null, 1001, null, 10, 1);
 
 		Assertions.assertEquals(1, problems.size());
 	}
 
 	@Test
 	void 일치하는게_없을땐_빈_리스트를_반환한다() {
-		final Path path = new Path();
-		final Course course = Course.of("test", path);
-		courseRepository.save(course);
 		entityManager.flush();
 		entityManager.clear();
 
-		final Problem problem1 = Problem.of(1L, 2L, "문제.jpeg", Difficulty.KILLER, AnswerType.MULTIPLE_CHOICE, course, "testCode", null, null, 1001, null, null);
-		final Problem problem2 = Problem.of(2L, 3L, "문제.jpeg", Difficulty.KILLER, AnswerType.MULTIPLE_CHOICE, course, "testCode", null, null, 1001, null, null);
+		final Problem problem1 = Problem.of(1L, 2L, "문제.jpeg", Difficulty.KILLER, AnswerType.MULTIPLE_CHOICE, "testPath", "testCode", null, null, 1001, null, null);
+		final Problem problem2 = Problem.of(2L, 3L, "문제.jpeg", Difficulty.KILLER, AnswerType.MULTIPLE_CHOICE, "testPath", "testCode", null, null, 1001, null, null);
 
 		problemRepository.save(problem1);
 		problemRepository.save(problem2);
@@ -161,14 +139,11 @@ class ProblemRepositoryTest {
 
 	@Test
 	void 조건_없을때_모든_문제를_조회한다() {
-		final Path path = new Path();
-		final Course course = Course.of("test", path);
-		courseRepository.save(course);
 		entityManager.flush();
 		entityManager.clear();
 
 		for (int i = 0; i < 10; i++) {
-			final Problem problem = Problem.of((long) i, 1L, "문제.jpeg", Difficulty.KILLER, AnswerType.MULTIPLE_CHOICE, course, "testCode", null, null, 1001, null, null);
+			final Problem problem = Problem.of((long) i, 1L, "문제.jpeg", Difficulty.KILLER, AnswerType.MULTIPLE_CHOICE, "testPath", "testCode", null, null, 1001, null, null);
 			problemRepository.save(problem);
 		}
 
@@ -177,20 +152,18 @@ class ProblemRepositoryTest {
 
 	@Test
 	void 특정_조건의_문제_총_갯수_조회() {
-		final Path path = new Path();
-		final Course course = Course.of("test", path);
-		courseRepository.save(course);
+
 		entityManager.flush();
 		entityManager.clear();
 
 		// level 5 문제들
 		for (int i = 0; i < 10; i++) {
-			final Problem problem = Problem.of((long) i, 1L, "문제.jpeg", Difficulty.HIGH, AnswerType.MULTIPLE_CHOICE, course, "testCode", null, null, 1001, null, null);
+			final Problem problem = Problem.of((long) i, 1L, "문제.jpeg", Difficulty.HIGH, AnswerType.MULTIPLE_CHOICE, "testPath", "testCode", null, null, 1001, null, null);
 			problemRepository.save(problem);
 		}
 		// level1 문제들
 		for (int i = 10; i < 20; i++) {
-			final Problem problem = Problem.of((long) i, 1L, "문제.jpeg", Difficulty.KILLER, AnswerType.MULTIPLE_CHOICE, course, "testCode", null, null, 1001, null, null);
+			final Problem problem = Problem.of((long) i, 1L, "문제.jpeg", Difficulty.KILLER, AnswerType.MULTIPLE_CHOICE, "testPath", "testCode", null, null, 1001, null, null);
 			problemRepository.save(problem);
 		}
 
@@ -200,20 +173,17 @@ class ProblemRepositoryTest {
 
 	@Test
 	void 조건_모두_널일때_모든_갯수_조회() {
-		final Path path = new Path();
-		final Course course = Course.of("test", path);
-		courseRepository.save(course);
 		entityManager.flush();
 		entityManager.clear();
 
 		// level 5 문제들
 		for (int i = 0; i < 10; i++) {
-			final Problem problem = Problem.of((long) i, 1L, "문제.jpeg", Difficulty.KILLER, AnswerType.MULTIPLE_CHOICE, course, "testCode", null, null, 1001, null, null);
+			final Problem problem = Problem.of((long) i, 1L, "문제.jpeg", Difficulty.KILLER, AnswerType.MULTIPLE_CHOICE, "testPath", "testCode", null, null, 1001, null, null);
 			problemRepository.save(problem);
 		}
 		// level1 문제들
 		for (int i = 10; i < 20; i++) {
-			final Problem problem = Problem.of((long) i, 1L, "문제.jpeg", Difficulty.KILLER, AnswerType.MULTIPLE_CHOICE, course, "testCode", null, null, 1001, null, null);
+			final Problem problem = Problem.of((long) i, 1L, "문제.jpeg", Difficulty.KILLER, AnswerType.MULTIPLE_CHOICE, "testPath", "testCode", null, null, 1001, null, null);
 			problemRepository.save(problem);
 		}
 
@@ -221,41 +191,13 @@ class ProblemRepositoryTest {
 	}
 
 	@Test
-	void 하위_단원까지_함께_조회된다() {
-		final Path path = new Path();
-		final Course parentCourse = Course.of("test", path);
-		courseRepository.save(parentCourse);
-		final Course childCourse = Course.of("test2", path.nextChild(path));
-		courseRepository.save(childCourse);
-
-		entityManager.flush();
-		entityManager.clear();
-
-		for (int i = 0; i < 10; i++) {
-			final Problem problem = Problem.of((long) i, 1L, "문제.jpeg", Difficulty.KILLER, AnswerType.MULTIPLE_CHOICE, parentCourse, "testCode", null, null, 1001, null, null);
-			problemRepository.save(problem);
-		}
-
-		for (int i = 10; i < 20; i++) {
-			final Problem problem = Problem.of((long) i, 1L, "문제.jpeg", Difficulty.KILLER, AnswerType.MULTIPLE_CHOICE, childCourse, "testCode", null, null, 1001, null, null);
-			problemRepository.save(problem);
-		}
-
-		Assertions.assertEquals(20,
-			problemRepository.query(null, null, null, null, null, path.getPath(), null, 1001, null, 100, 1).size());
-	}
-
-	@Test
 	void 질문_페이징시_limit을_활용하여_두번의_쿼리로_해결한다() {
-		final Course course = Course.of("test2", new Path());
-		courseRepository.save(course);
-
 		entityManager.flush();
 		entityManager.clear();
 
 		// 데이터 삽입 ( 문제당 답안 2개씩 )
 		for (int i = 0; i < 20; i++) {
-			final Problem problem = Problem.of((long) i, 1L, "문제.jpeg", Difficulty.KILLER, AnswerType.MULTIPLE_CHOICE, course, "testCode", null, null, 1001, null, null);
+			final Problem problem = Problem.of((long) i, 1L, "문제.jpeg", Difficulty.KILLER, AnswerType.MULTIPLE_CHOICE, "testPath", "testCode", null, null, 1001, null, null);
 			final Set<Answer> answers = Set.of(Answer.of((long) i, "1", problem), Answer.of((long) i + 20, "2", problem));
 			problem.setAnswers(answers);
 			problemRepository.save(problem);

--- a/domain/mathrank-problem-domain/src/test/java/kr/co/mathrank/domain/problem/service/ProblemQueryServiceTest.java
+++ b/domain/mathrank-problem-domain/src/test/java/kr/co/mathrank/domain/problem/service/ProblemQueryServiceTest.java
@@ -12,10 +12,7 @@ import kr.co.mathrank.domain.problem.core.AnswerType;
 import kr.co.mathrank.domain.problem.core.Difficulty;
 import kr.co.mathrank.domain.problem.dto.ProblemQueryCommand;
 import kr.co.mathrank.domain.problem.dto.ProblemQueryPageResult;
-import kr.co.mathrank.domain.problem.entity.Course;
-import kr.co.mathrank.domain.problem.entity.Path;
 import kr.co.mathrank.domain.problem.entity.Problem;
-import kr.co.mathrank.domain.problem.repository.CourseRepository;
 import kr.co.mathrank.domain.problem.repository.ProblemRepository;
 
 @SpringBootTest
@@ -27,20 +24,15 @@ class ProblemQueryServiceTest {
 	private ProblemQueryService problemQueryService;
 	@Autowired
 	private ProblemRepository problemRepository;
-	@Autowired
-	private CourseRepository courseRepository;
 
 	@Test
 	void 문제_조회_테스트() {
-		final Path path = new Path();
-		final Course course = Course.of("test", path);
-		courseRepository.save(course);
 		entityManager.flush();
 		entityManager.clear();
 
 		// memberId가 1인 문제를 10개 등록한다.
 		for (int i = 0; i < 10; i++) {
-			final Problem problem = Problem.of((long) i, 1L, "문제.jpeg", Difficulty.KILLER, AnswerType.MULTIPLE_CHOICE, course, "testCode", null, null, 1001, null, null);
+			final Problem problem = Problem.of((long) i, 1L, "문제.jpeg", Difficulty.KILLER, AnswerType.MULTIPLE_CHOICE, "testPath", "testCode", null, null, 1001, null, null);
 			problemRepository.save(problem);
 		}
 

--- a/domain/mathrank-problem-domain/src/test/java/kr/co/mathrank/domain/problem/service/ProblemServiceTest.java
+++ b/domain/mathrank-problem-domain/src/test/java/kr/co/mathrank/domain/problem/service/ProblemServiceTest.java
@@ -23,11 +23,8 @@ import kr.co.mathrank.domain.problem.core.Difficulty;
 import kr.co.mathrank.domain.problem.dto.ProblemDeleteCommand;
 import kr.co.mathrank.domain.problem.dto.ProblemRegisterCommand;
 import kr.co.mathrank.domain.problem.dto.ProblemUpdateCommand;
-import kr.co.mathrank.domain.problem.entity.Course;
-import kr.co.mathrank.domain.problem.entity.Path;
 import kr.co.mathrank.domain.problem.entity.Problem;
 import kr.co.mathrank.domain.problem.exception.CannotAccessProblemException;
-import kr.co.mathrank.domain.problem.repository.CourseRepository;
 import kr.co.mathrank.domain.problem.repository.ProblemRepository;
 
 @SpringBootTest(properties = """
@@ -40,8 +37,6 @@ class ProblemServiceTest {
 	private ProblemRepository problemRepository;
 	@PersistenceContext
 	private EntityManager entityManager;
-	@Autowired
-	private CourseRepository courseRepository;
 	@MockitoBean
 	private SchoolLocationManager schoolLocationManager;
 
@@ -53,17 +48,14 @@ class ProblemServiceTest {
 
 	@Test
 	void 업데이트_성공() {
-		final Path path = new Path();
-		final Course course = Course.of("test", path);
-		courseRepository.save(course);
 		entityManager.flush();
 		entityManager.clear();
 
-		final ProblemRegisterCommand command = new ProblemRegisterCommand(1L, "image.jpeg", "image.jpeg", AnswerType.MULTIPLE_CHOICE, path.getPath(), Difficulty.KILLER, "testCode",
+		final ProblemRegisterCommand command = new ProblemRegisterCommand(1L, "image.jpeg", "image.jpeg", AnswerType.MULTIPLE_CHOICE, "testPath", Difficulty.KILLER, "testCode",
 			Set.of("1"), 1001, null, null);
 		final Long problemId = problemService.save(command);
 
-		final ProblemUpdateCommand updateCommand = new ProblemUpdateCommand(problemId, 1L, "newImage.jpeg", "newImage.jpeg", AnswerType.SHORT_ANSWER, Difficulty.KILLER, path.getPath(), "newTestCode", Set.of("newAnswer"), 1212, "solutionVideoLink", null);
+		final ProblemUpdateCommand updateCommand = new ProblemUpdateCommand(problemId, 1L, "newImage.jpeg", "newImage.jpeg", AnswerType.SHORT_ANSWER, Difficulty.KILLER, "testPath", "newTestCode", Set.of("newAnswer"), 1212, "solutionVideoLink", null);
 		problemService.update(updateCommand);
 
 		final Problem updatedProblem = problemRepository.findById(problemId)
@@ -77,29 +69,23 @@ class ProblemServiceTest {
 
 	@Test
 	void 소유자가_아니면_업데이트_불가() {
-		final Path path = new Path();
-		final Course course = Course.of("test", path);
-		courseRepository.save(course);
 		entityManager.flush();
 		entityManager.clear();
 
-		final ProblemRegisterCommand command = new ProblemRegisterCommand(1L, "image.jpeg", "image.jpeg", AnswerType.MULTIPLE_CHOICE, path.getPath(), Difficulty.KILLER, "testCode", Set.of("test"), 1001, null, null);
+		final ProblemRegisterCommand command = new ProblemRegisterCommand(1L, "image.jpeg", "image.jpeg", AnswerType.MULTIPLE_CHOICE, "testPath", Difficulty.KILLER, "testCode", Set.of("test"), 1001, null, null);
 		final Long problemId = problemService.save(command);
 
-		final ProblemUpdateCommand updateCommand = new ProblemUpdateCommand(problemId, 2L, "newImage.jpeg", "newImage.jpeg", AnswerType.SHORT_ANSWER, Difficulty.KILLER, path.getPath(), "newTestCode", Set.of("newAnswer"), 1212, "solutionVideoLink", null);
+		final ProblemUpdateCommand updateCommand = new ProblemUpdateCommand(problemId, 2L, "newImage.jpeg", "newImage.jpeg", AnswerType.SHORT_ANSWER, Difficulty.KILLER, "testPath", "newTestCode", Set.of("newAnswer"), 1212, "solutionVideoLink", null);
 
 		Assertions.assertThrows(CannotAccessProblemException.class, () -> problemService.update(updateCommand));
 	}
 
 	@Test
 	void 삭제_성공() {
-		final Path path = new Path();
-		final Course course = Course.of("test", path);
-		courseRepository.save(course);
 		entityManager.flush();
 		entityManager.clear();
 
-		final ProblemRegisterCommand command = new ProblemRegisterCommand(1L, "image.jpeg", "image.jpeg", AnswerType.MULTIPLE_CHOICE, path.getPath(), Difficulty.KILLER, "testCode", Set.of("answer"), 1001, null, null);
+		final ProblemRegisterCommand command = new ProblemRegisterCommand(1L, "image.jpeg", "image.jpeg", AnswerType.MULTIPLE_CHOICE, "testPath", Difficulty.KILLER, "testCode", Set.of("answer"), 1001, null, null);
 		final Long problemId = problemService.save(command);
 
 		entityManager.flush();
@@ -116,14 +102,11 @@ class ProblemServiceTest {
 
 	@Test
 	void 본인_문제만_삭제가능() {
-		final Path path = new Path();
-		final Course course = Course.of("test", path);
-		courseRepository.save(course);
 		entityManager.flush();
 		entityManager.clear();
 
 		final ProblemRegisterCommand command = new ProblemRegisterCommand(1L, "image.jpeg", "image.jpeg", AnswerType.MULTIPLE_CHOICE,
-			path.getPath(), Difficulty.KILLER, "testCode", Set.of("answer"), 1001, null, null);
+			"testPath", Difficulty.KILLER, "testCode", Set.of("answer"), 1001, null, null);
 		final Long problemId = problemService.save(command);
 
 		final ProblemDeleteCommand deleteCommand = new ProblemDeleteCommand(problemId, 2L);

--- a/domain/mathrank-problem-domain/src/test/java/kr/co/mathrank/domain/problem/service/ProblemSolveServiceTest.java
+++ b/domain/mathrank-problem-domain/src/test/java/kr/co/mathrank/domain/problem/service/ProblemSolveServiceTest.java
@@ -16,9 +16,6 @@ import kr.co.mathrank.domain.problem.core.Difficulty;
 import kr.co.mathrank.domain.problem.dto.ProblemRegisterCommand;
 import kr.co.mathrank.domain.problem.dto.ProblemSolveCommand;
 import kr.co.mathrank.domain.problem.dto.ProblemSolveResult;
-import kr.co.mathrank.domain.problem.entity.Course;
-import kr.co.mathrank.domain.problem.entity.Path;
-import kr.co.mathrank.domain.problem.repository.CourseRepository;
 import lombok.RequiredArgsConstructor;
 
 @SpringBootTest
@@ -29,20 +26,14 @@ class ProblemSolveServiceTest {
 	private ProblemSolveService problemSolveService;
 	@Autowired
 	private ProblemService problemService;
-	@Autowired
-	private CourseRepository courseRepository;
 	@MockitoBean
 	private SchoolLocationManager schoolLocationManager;
 
 	@Test
 	void 제출된_정답이_실제_정답이랑_정확히_일치할때_성공한다() {
-		final Path path = new Path();
-		final Course course = Course.of("test", path);
-		courseRepository.save(course);
-
 		Mockito.when(schoolLocationManager.getSchoolLocation(Mockito.anyString())).thenReturn("test");
 
-		final ProblemRegisterCommand command = new ProblemRegisterCommand(1L, "image.jpeg", "image.jpeg", AnswerType.MULTIPLE_CHOICE, path.getPath(), Difficulty.KILLER, "testCode",
+		final ProblemRegisterCommand command = new ProblemRegisterCommand(1L, "image.jpeg", "image.jpeg", AnswerType.MULTIPLE_CHOICE, "testPath", Difficulty.KILLER, "testCode",
 			Set.of("1"), 1001, null, null);
 
 		final Long problemId = problemService.save(command);
@@ -56,13 +47,9 @@ class ProblemSolveServiceTest {
 
 	@Test
 	void 제출된_정답이_일치하지만_더많으면_실패한다() {
-		final Path path = new Path();
-		final Course course = Course.of("test", path);
-		courseRepository.save(course);
-
 		Mockito.when(schoolLocationManager.getSchoolLocation(Mockito.anyString())).thenReturn("test");
 
-		final ProblemRegisterCommand command = new ProblemRegisterCommand(1L, "image.jpeg", "image.jpeg", AnswerType.MULTIPLE_CHOICE, path.getPath(), Difficulty.KILLER, "testCode",
+		final ProblemRegisterCommand command = new ProblemRegisterCommand(1L, "image.jpeg", "image.jpeg", AnswerType.MULTIPLE_CHOICE, "testPath", Difficulty.KILLER, "testCode",
 			Set.of("1"), 1001, null, null);
 		final Long problemId = problemService.save(command);
 
@@ -76,13 +63,9 @@ class ProblemSolveServiceTest {
 
 	@Test
 	void 제출된_정답에_정답이_포함되지_않으면_실패한다() {
-		final Path path = new Path();
-		final Course course = Course.of("test", path);
-		courseRepository.save(course);
-
 		Mockito.when(schoolLocationManager.getSchoolLocation(Mockito.anyString())).thenReturn("test");
 
-		final ProblemRegisterCommand command = new ProblemRegisterCommand(1L, "image.jpeg", "image.jpeg", AnswerType.MULTIPLE_CHOICE, path.getPath(), Difficulty.KILLER, "testCode",
+		final ProblemRegisterCommand command = new ProblemRegisterCommand(1L, "image.jpeg", "image.jpeg", AnswerType.MULTIPLE_CHOICE, "testPath", Difficulty.KILLER, "testCode",
 			Set.of("1"), 1001, null, null);
 		final Long problemId = problemService.save(command);
 

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/entity/SingleProblemSolver.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/entity/SingleProblemSolver.java
@@ -16,7 +16,7 @@ import lombok.ToString;
 @Entity
 @Table(
 	uniqueConstraints = @UniqueConstraint(
-		name = "unique_memberId_singleProblemId",
+		name = "unique_singleProblemSolver_memberId_singleProblemId",
 		columnNames = {"member_id", "single_problem_read_model_id"}
 	)
 )

--- a/settings.gradle
+++ b/settings.gradle
@@ -19,6 +19,7 @@ include(
         'app:api:mathrank-auth-api',
         'app:api:mathrank-school-read-api',
         'app:api:mathrank-course-api',
+        'app:api:mathrank-course-inner-api',
         'app:batch',
         'app:consumer',
         'app:consumer:mathrank-problem-single-consumer',
@@ -26,6 +27,7 @@ include(
 
         'client',
         'client:internal',
+        'client:internal:mathrank-course-client',
         'client:internal:mathrank-member-client',
         'client:internal:mathrank-problem-client',
         'client:external',

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,6 +18,7 @@ include(
         'app:api:mathrank-api-common',
         'app:api:mathrank-auth-api',
         'app:api:mathrank-school-read-api',
+        'app:api:mathrank-course-api',
         'app:batch',
         'app:consumer',
         'app:consumer:mathrank-problem-single-consumer',

--- a/settings.gradle
+++ b/settings.gradle
@@ -31,6 +31,7 @@ include(
         'client:external:mathrank-school',
 
         'domain',
+        'domain:mathrank-course-domain',
         'domain:mathrank-problem-assessment-domain',
         'domain:mathrank-image-domain',
         'domain:mathrank-auth-domain',


### PR DESCRIPTION
#68 

- `course` 도메인이 여러 모듈에서 사용되야함에 따라, 모듈 분리
- 또한, `Problem` 과 생명주기가 다름에 따라 모듈 분리
  - 번경 전: `Problem` 도메인에 속해있음
  - 변경 후: 개별 모듈로 분리

- `SingleProblem`에서 `client`모듈 을 통해 데이터 조회 
- `Problem`에서 `client`모듈 을 통해 데이터 조회 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Single-problem read endpoint now returns paginated, sortable results and includes course hierarchy info.
  - New course APIs plus an internal (hidden) course endpoint enable course lookups.

- **Refactor**
  - Problems now reference courses by path instead of a linked course entity (no user-facing behavior changes).

- **Chores**
  - Added course modules, internal course client, dependencies and course client host/port config.

- **Tests**
  - Tests updated to use course-path approach and align with domain layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->