### PR TITLE
전역 캐시 모듈 구현 

### DIFF
--- a/app/api/monolith-api/build.gradle
+++ b/app/api/monolith-api/build.gradle
@@ -18,4 +18,6 @@ dependencies {
     implementation project(':app:init:mathrank-auth-init')
 
     implementation project(':app:consumer:mathrank-problem-single-read-consumer-monolith')
+
+    implementation project(':common:mathrank-cache-caffeine')
 }

--- a/common/mathrank-cache-caffeine/build.gradle
+++ b/common/mathrank-cache-caffeine/build.gradle
@@ -1,0 +1,6 @@
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'com.github.ben-manes.caffeine:caffeine'
+
+    implementation project(':common:mathrank-cache')
+}

--- a/common/mathrank-cache-caffeine/src/main/java/kr/co/mathrank/common/cache/manager/CaffeineCacheCustomizerConfiguration.java
+++ b/common/mathrank-cache-caffeine/src/main/java/kr/co/mathrank/common/cache/manager/CaffeineCacheCustomizerConfiguration.java
@@ -1,0 +1,37 @@
+package kr.co.mathrank.common.cache.manager;
+
+import java.util.List;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+import kr.co.mathrank.common.cache.RequiredCacheSpec;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@EnableCaching
+@Configuration
+public class CaffeineCacheCustomizerConfiguration {
+	@Bean
+	public CacheManager applyRequireCacheSpecs(final List<RequiredCacheSpec> requireCacheSpecs) {
+		final CaffeineCacheManager cacheManager = new CaffeineCacheManager();
+		for (final RequiredCacheSpec cacheSpec : requireCacheSpecs) {
+			final Cache<Object, Object> cache = Caffeine.newBuilder()
+				.maximumSize(200L)  // 엔트리 최대 200개
+				.expireAfterWrite(cacheSpec.ttl()).build();
+			cacheManager.registerCustomCache(cacheSpec.cacheName(), cache);
+
+			log.info(
+				"[CaffeineCacheCustomizerConfiguration.applyRequireCacheSpecs]: registered cache spec - request module: {}, cache name: {}, cache TTL: {}",
+				cacheSpec.moduleName(), cacheSpec.cacheName(), cacheSpec.ttl());
+		}
+
+		return cacheManager;
+	}
+}

--- a/common/mathrank-cache-caffeine/src/main/java/kr/co/mathrank/common/cache/manager/CaffeineCacheCustomizerConfiguration.java
+++ b/common/mathrank-cache-caffeine/src/main/java/kr/co/mathrank/common/cache/manager/CaffeineCacheCustomizerConfiguration.java
@@ -11,17 +11,19 @@ import org.springframework.context.annotation.Configuration;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 
+import kr.co.mathrank.common.cache.CacheSpecAssembler;
 import kr.co.mathrank.common.cache.RequiredCacheSpec;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @EnableCaching
 @Configuration
-public class CaffeineCacheCustomizerConfiguration {
+public class CaffeineCacheCustomizerConfiguration implements CacheSpecAssembler {
+	@Override
 	@Bean
-	public CacheManager applyRequireCacheSpecs(final List<RequiredCacheSpec> requireCacheSpecs) {
+	public CacheManager assemble(List<RequiredCacheSpec> requiredCacheSpecs) {
 		final CaffeineCacheManager cacheManager = new CaffeineCacheManager();
-		for (final RequiredCacheSpec cacheSpec : requireCacheSpecs) {
+		for (final RequiredCacheSpec cacheSpec : requiredCacheSpecs) {
 			final Cache<Object, Object> cache = Caffeine.newBuilder()
 				.maximumSize(200L)  // 엔트리 최대 200개
 				.expireAfterWrite(cacheSpec.ttl()).build();

--- a/common/mathrank-cache/build.gradle
+++ b/common/mathrank-cache/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+}

--- a/common/mathrank-cache/src/main/java/kr/co/mathrank/common/cache/CacheSpecAssembler.java
+++ b/common/mathrank-cache/src/main/java/kr/co/mathrank/common/cache/CacheSpecAssembler.java
@@ -1,0 +1,31 @@
+package kr.co.mathrank.common.cache;
+
+import java.util.List;
+
+import org.springframework.cache.CacheManager;
+
+/**
+ * 여러 모듈에서 제공한 {@link RequiredCacheSpec} 들을 조립하여
+ * 최종적으로 사용할 {@link CacheManager} 인스턴스를 생성하는 계약(Assembler) 인터페이스입니다.
+ *
+ * <p>구현체는 환경에 따라 다른 CacheManager를 구성할 수 있습니다.
+ * 예를 들어,
+ * <ul>
+ *   <li>모놀리식 환경: {@code CaffeineCacheManager} 기반으로 엔트리 수/TTL을 설정</li>
+ *   <li>MSA 환경: {@code RedisCacheManager} 기반으로 캐시별 TTL/Serializer를 설정</li>
+ * </ul>
+ *
+ * <p>전역 구성 클래스에서 모든 모듈의 {@code RequiredCacheSpec} 리스트를 수집해
+ * 이 인터페이스를 구현한 Assembler에게 전달하면,
+ * 중앙 CacheManager를 생성하고 Spring 컨텍스트에 빈으로 등록할 수 있습니다.
+ */
+public interface CacheSpecAssembler {
+
+	/**
+	 * 주어진 모듈별 필수 캐시 스펙 목록을 기반으로 CacheManager를 조립하여 반환합니다.
+	 *
+	 * @param requiredCacheSpecs 각 모듈이 정의한 캐시 이름과 TTL 등의 사양
+	 * @return 조립된 CacheManager (Caffeine, Redis 등 구체 구현체)
+	 */
+	public abstract CacheManager assemble(List<RequiredCacheSpec> requiredCacheSpecs);
+}

--- a/common/mathrank-cache/src/main/java/kr/co/mathrank/common/cache/CacheSpecAssemblerVerifier.java
+++ b/common/mathrank-cache/src/main/java/kr/co/mathrank/common/cache/CacheSpecAssemblerVerifier.java
@@ -1,0 +1,35 @@
+package kr.co.mathrank.common.cache;
+
+import java.util.List;
+
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 애플리케이션 구동 완료 시점에 {@link CacheSpecAssembler} 빈들의 등록 여부를 검증하고 로그를 남기는 컴포넌트.
+ *
+ * <p>주요 목적:
+ * <ul>
+ *   <li>멀티모듈 환경에서 모듈별 캐시 스펙 조립기가 정상적으로 등록됐는지 초기 구동 단계에서 점검</li>
+ *   <li>운영 중 캐시 스펙 조립기 누락 문제를 조기 발견 후 로깅</li>
+ * </ul>
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+class CacheSpecAssemblerVerifier {
+	private final List<CacheSpecAssembler> cacheSpecAssemblers;
+
+	@EventListener(ApplicationReadyEvent.class)
+	private void verifyAssemblers() {
+		if (cacheSpecAssemblers.isEmpty()) {
+			log.warn("[RequiredCacheSpecAssemblerIdentifier.verifyAssemblers] cannot find any cache assemblers");
+			return;
+		}
+		log.info("[RequiredCacheSpecAssemblerIdentifier.verifyAssemblers] cache assemblers detected - count: {}", cacheSpecAssemblers.size());
+	}
+}

--- a/common/mathrank-cache/src/main/java/kr/co/mathrank/common/cache/RequiredCacheSpec.java
+++ b/common/mathrank-cache/src/main/java/kr/co/mathrank/common/cache/RequiredCacheSpec.java
@@ -1,0 +1,24 @@
+package kr.co.mathrank.common.cache;
+
+import java.time.Duration;
+
+/**
+ * 각 모듈에서 필수적으로 정의해야 하는 캐시 사양(스펙) 인터페이스입니다.
+ * <p>
+ * 이 인터페이스를 구현하여 모듈 단위로 캐시 이름, TTL 등
+ * 캐시 설정 정보를 중앙 구성(예: CacheManager)으로 전달할 수 있습니다.
+ *
+ * <ul>
+ *   <li>{@link #moduleName()} - 해당 캐시를 정의한 모듈명 (로깅/추적용)</li>
+ *   <li>{@link #cacheName()} - 캐시 식별자. CacheManager에 등록될 캐시 이름</li>
+ *   <li>{@link #ttl()} - Time-To-Live (만료 시간). 캐시 항목의 유효 기간</li>
+ * </ul>
+ *
+ * 구현체는 보통 @Configuration 클래스나 @Bean 으로 제공되어,
+ * 전역 CacheManager 초기화 시 수집되어 적용됩니다.
+ */
+public interface RequiredCacheSpec {
+	public abstract String moduleName();
+	public abstract String cacheName();
+	public abstract Duration ttl();
+}

--- a/common/mathrank-cache/src/main/java/kr/co/mathrank/common/cache/RequiredCacheSpecVerifier.java
+++ b/common/mathrank-cache/src/main/java/kr/co/mathrank/common/cache/RequiredCacheSpecVerifier.java
@@ -1,0 +1,57 @@
+package kr.co.mathrank.common.cache;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * {@link RequiredCacheSpec} 들을 모아 캐시 이름의 중복 여부를 검증하는 컴포넌트.
+ *
+ * <p>동작 시점:
+ * <ul>
+ *   <li>{@link ApplicationReadyEvent} 발생 시점(애플리케이션 기동 완료 직후)에 실행된다.</li>
+ * </ul>
+ *
+ * <p>검증 내용:
+ * <ul>
+ *   <li>모든 {@link RequiredCacheSpec} 의 {@code cacheName()} 값을 수집한다.</li>
+ *   <li>이미 등장한 캐시 이름이 또 나오면 에러 로그를 남기고 {@link IllegalStateException} 을 발생시켜
+ *       애플리케이션 기동을 중단한다 (fail-fast).</li>
+ *   <li>중복이 없으면 아무 동작 없이 정상적으로 통과한다.</li>
+ * </ul>
+ *
+ * <p>주요 목적:
+ * <ul>
+ *   <li>멀티 모듈 환경에서 서로 다른 모듈이 동일한 캐시 이름을 선언하는 문제를 사전에 차단</li>
+ *   <li>운영 중 캐시 이름 충돌로 인해 TTL/설정이 꼬이는 문제를 예방</li>
+ * </ul>
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+class RequiredCacheSpecVerifier {
+	private final List<RequiredCacheSpec> requiredCacheSpecs;
+
+	@EventListener(ApplicationReadyEvent.class)
+	private void verifyCacheNamesDuplicated() {
+		final Set<String> cacheNames = new HashSet<>();
+
+		for (final RequiredCacheSpec requiredCacheSpec : requiredCacheSpecs) {
+			final String cacheName = requiredCacheSpec.cacheName();
+
+			if (cacheNames.contains(cacheName)) {
+				log.error("[RequiredCacheSpecVerifier.verifyCacheNamesDuplicated] cache name duplicated : {}", cacheName);
+				throw new IllegalStateException("cache name duplicated");
+			} else {
+				cacheNames.add(requiredCacheSpec.cacheName());
+			}
+		}
+	}
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -45,6 +45,7 @@ include(
 
         'common',
         'common:mathrank-cache',
+        'common:mathrank-cache-caffeine',
         'common:mathrank-querydsl',
         'common:mathrank-page',
         'common:mathrank-exception',

--- a/settings.gradle
+++ b/settings.gradle
@@ -44,6 +44,7 @@ include(
         'domain:mathrank-problem-single-read-domain',
 
         'common',
+        'common:mathrank-cache',
         'common:mathrank-querydsl',
         'common:mathrank-page',
         'common:mathrank-exception',


### PR DESCRIPTION
각 모듈별로 캐시를 독립적으로 캐시 이름과 TTL을 설정하여 사용할 수 있도록 합니다.

1. **유연한 캐시 구성 가능**  
   `RequiredCacheSpec`을 빈으로 등록하여 각 모듈이 자신의 캐시 사양을 설정할 수 있습니다. (이름, TTL)

2. **캐시 충돌 방지**  
  `RequiredCacheSpecVerifier` 에서 캐시 이름 중복 시 애플리케이션이 실패하도록 설계해, 의도치 않은 캐시 충돌을 예방합니다.

3. **운영 편의성 향상**  
   초기 캐시 구성을 로그에 남겨 운영 시 설정 확인을 용이하게 했습니다.

4. **점진적 확장 가능 구조**  
   이번 구조를 바탕으로, 향후 Redis, Ehcache 등 다양한 캐시 백엔드로의 확장도 용이합니다.

# 사용 방법 
1. 의존성 추가
```
implementation ':common:mathrank-cache`
```
2. 사용할 캐 시이름 등록
```
@Configuration
public class CacheConfiguration {
	public static final String CURRENT_MODULE_CACHE_NAME = "my::cache::name"; // 사용할 캐시 이름

	@Bean
	public RequiredCacheSpec requiredCacheSpec() {
		return new RequiredCacheSpec() {
			@Override
			public String moduleName() {
				return "current-module-name"; // 현재 모듈 명
			}

			@Override
			public String cacheName() {
				return CURRENT_MODULE_CACHE_NAME;
			}

			@Override
			public Duration ttl() {
				return Duration.ofSeconds(1000);
			}
		};
	}
}
```
3. 캐시 사용 
```
@Service
@Validated
@RequiredArgsConstructor
@CacheConfig(cacheNames = CURRENT_MODULE_CACHE_NAME) // 사용할 캐시 이름 적용
public class CourseQueryService {
	private final CourseRepository courseRepository;

	@Cacheable(key = "#pathSource")
	public CourseQueryResults queryChildes(@NotNull final String pathSource) {
		final Path path = new Path(pathSource);
...
```
