### PR TITLE
assessment 도메인에서 필드명 차이로 인한 에러, 

### DIFF
--- a/app/api/mathrank-problem-assessment-api/src/main/java/kr/co/mathrank/app/api/assessment/Requests.java
+++ b/app/api/mathrank-problem-assessment-api/src/main/java/kr/co/mathrank/app/api/assessment/Requests.java
@@ -59,10 +59,11 @@ public class Requests {
 		@NotNull
 		List<List<String>> submittedAnswers,
 		@NotNull
-		Duration elapsedTime
+		Long elapsedTimeSeconds
 	) {
 		public SubmissionRegisterCommand toCommand(final Long memberId) {
-			return new SubmissionRegisterCommand(memberId, assessmentId, submittedAnswers, elapsedTime);
+			return new SubmissionRegisterCommand(memberId, assessmentId, submittedAnswers,
+				Duration.ofSeconds(elapsedTimeSeconds));
 		}
 	}
 }

--- a/app/consumer/mathrank-assessment-consumer-monolith/src/main/java/kr/co/mathrank/app/consumer/problem/assessment/AssessmentMonolithEventConsumer.java
+++ b/app/consumer/mathrank-assessment-consumer-monolith/src/main/java/kr/co/mathrank/app/consumer/problem/assessment/AssessmentMonolithEventConsumer.java
@@ -46,7 +46,7 @@ public class AssessmentMonolithEventConsumer {
 		Long memberId,
 		Long submissionId,
 		LocalDateTime submittedTime,
-		Duration elapsedTime
+		Long elapsedTimeSeconds
 	) implements EventPayload {
 	}
 }

--- a/client/internal/mathrank-problem-client/src/main/java/kr/co/mathrank/client/internal/problem/SolveResult.java
+++ b/client/internal/mathrank-problem-client/src/main/java/kr/co/mathrank/client/internal/problem/SolveResult.java
@@ -5,7 +5,7 @@ import java.util.Set;
 
 public record SolveResult(
 	Boolean success,
-	Set<String> realAnswer,
+	Set<String> correctAnswer,
 	List<String> submittedAnswer
 ) {
 }

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/service/ItemGradeManager.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/service/ItemGradeManager.java
@@ -1,5 +1,6 @@
 package kr.co.mathrank.domain.problem.assessment.service;
 
+import java.util.Collections;
 import java.util.List;
 
 import org.springframework.stereotype.Component;
@@ -10,7 +11,9 @@ import kr.co.mathrank.client.internal.problem.ProblemClient;
 import kr.co.mathrank.client.internal.problem.SolveResult;
 import kr.co.mathrank.domain.problem.assessment.entity.GradeResult;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Component
 @Validated
 @RequiredArgsConstructor
@@ -19,13 +22,14 @@ class ItemGradeManager {
 
 	public GradeResult gradeItemSubmission(@NotNull final Long problemId, @NotNull final List<String> submittedAnswer) {
 		final SolveResult solveResult = problemClient.matchAnswer(problemId, submittedAnswer);
+		log.info("[ItemGradeManager.gradeItemSubmission] matchedInfo: {}", solveResult);
 		return create(solveResult, problemId);
 	}
 
 	private GradeResult create(final SolveResult solveResult, final Long problemId) {
 		return new GradeResult(
 			problemId,
-			solveResult.realAnswer().stream().toList(),
+			solveResult.correctAnswer().stream().toList(),
 			solveResult.success());
 	}
 }

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/service/SubmissionRegisterService.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/service/SubmissionRegisterService.java
@@ -50,7 +50,7 @@ public class SubmissionRegisterService {
 			command.memberId(),
 			assessmentSubmission.getId(),
 			assessmentSubmission.getSubmittedAt(),
-			assessmentSubmission.getElapsedTime()
+			assessmentSubmission.getElapsedTime().getSeconds()
 		));
 
 		return assessmentSubmission.getId();
@@ -61,7 +61,7 @@ public class SubmissionRegisterService {
 		Long memberId,
 		Long submissionId,
 		LocalDateTime submittedTime,
-		Duration elapsedTime
+		Long elapsedTimeSeconds
 	) implements EventPayload {
 	}
 }

--- a/domain/mathrank-problem-single-domain/src/main/java/kr/co/mathrank/domain/problem/single/dto/SingleProblemSolveResult.java
+++ b/domain/mathrank-problem-single-domain/src/main/java/kr/co/mathrank/domain/problem/single/dto/SingleProblemSolveResult.java
@@ -17,7 +17,7 @@ public record SingleProblemSolveResult(
 	public static SingleProblemSolveResult from(SolveResult solveResult) {
 		return new SingleProblemSolveResult(
 			solveResult.success(),
-			solveResult.realAnswer(),
+			solveResult.correctAnswer(),
 			solveResult.submittedAnswer()
 		);
 	}


### PR DESCRIPTION
- 문제 풀이 API에서 `json` 필드명이 달라 매핑되지 않던 오류 수정 ( `NullPointerException` 해결 )
- `Duration` 타입을 API에서 `Long` 타입 초 로 노출하도록 변경