### PR TITLE
문제집 답안지 제출한 유니크한 사용자 수 카운트 기능 구현

### DIFF
--- a/domain/mathrank-problem-assessment-domain/build.gradle
+++ b/domain/mathrank-problem-assessment-domain/build.gradle
@@ -12,4 +12,8 @@ dependencies {
     implementation project(':client:internal:mathrank-problem-client')
 
     testImplementation project(':common:mathrank-event-publisher-test')
+
+    testImplementation 'org.testcontainers:junit-jupiter'
+    testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+    testImplementation 'org.testcontainers:mysql'
 }

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/entity/Assessment.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/entity/Assessment.java
@@ -52,7 +52,7 @@ public class Assessment {
 	@OneToMany(mappedBy = "assessment", orphanRemoval = true, cascade = CascadeType.PERSIST)
 	private final List<AssessmentSubmission> assessmentSubmissions = new ArrayList<>();
 
-	@Setter
+	@Setter(AccessLevel.NONE)
 	private Long distinctTriedMemberCount = 0L;
 
 	@CreationTimestamp

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/entity/Assessment.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/entity/Assessment.java
@@ -52,6 +52,9 @@ public class Assessment {
 	@OneToMany(mappedBy = "assessment", orphanRemoval = true, cascade = CascadeType.PERSIST)
 	private final List<AssessmentSubmission> assessmentSubmissions = new ArrayList<>();
 
+	@Setter
+	private Long distinctTriedMemberCount = 0L;
+
 	@CreationTimestamp
 	@Setter(AccessLevel.NONE)
 	private LocalDateTime createdAt;
@@ -63,6 +66,10 @@ public class Assessment {
 		assessment.assessmentDuration = assessmentDuration;
 
 		return assessment;
+	}
+
+	public void increaseDistinctMemberCount() {
+		distinctTriedMemberCount++;
 	}
 
 	/**

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/entity/AssessmentSubmission.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/entity/AssessmentSubmission.java
@@ -18,10 +18,12 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -29,6 +31,9 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Entity
+@Table(
+	indexes = @Index(name = "idx_memberId_assessmentId", columnList = "member_id, assessment_id")
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AssessmentSubmission {

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/repository/AssessmentRepository.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/repository/AssessmentRepository.java
@@ -3,9 +3,11 @@ package kr.co.mathrank.domain.problem.assessment.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import jakarta.persistence.LockModeType;
 import kr.co.mathrank.domain.problem.assessment.entity.Assessment;
 
 public interface AssessmentRepository extends JpaRepository<Assessment, Long> {
@@ -14,5 +16,6 @@ public interface AssessmentRepository extends JpaRepository<Assessment, Long> {
 				 LEFT JOIN FETCH ass.assessmentItems
 						  WHERE ass.id = :assessmentId
 		""")
-	Optional<Assessment> findWithItems(@Param("assessmentId") final Long assessmentId);
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	Optional<Assessment> findWithItemsForUpdate(@Param("assessmentId") final Long assessmentId);
 }

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/repository/AssessmentSubmissionRepository.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/repository/AssessmentSubmissionRepository.java
@@ -1,11 +1,14 @@
 package kr.co.mathrank.domain.problem.assessment.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import jakarta.persistence.LockModeType;
 import kr.co.mathrank.domain.problem.assessment.entity.AssessmentSubmission;
 
 public interface AssessmentSubmissionRepository extends JpaRepository<AssessmentSubmission, Long> {
@@ -24,4 +27,12 @@ public interface AssessmentSubmissionRepository extends JpaRepository<Assessment
 		WHERE s.id = :assessmentSubmissionId
 		""")
 	Optional<AssessmentSubmission> findByIdWithSubmittedItemAnswers(@Param("assessmentSubmissionId") Long assessmentSubmissionId);
+
+	@Query("""
+		SELECT ass
+		FROM AssessmentSubmission ass
+		WHERE ass.assessment.id = :assessmentId AND ass.memberId = :memberId
+		""")
+	@Lock(LockModeType.PESSIMISTIC_READ)
+	List<AssessmentSubmission> findAllByAssessmentIdAndMemberIdForShare(@Param("assessmentId") Long assessmentId, @Param("memberId") Long memberId);
 }

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/service/SubmissionRegisterService.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/service/SubmissionRegisterService.java
@@ -29,30 +29,75 @@ public class SubmissionRegisterService {
 
 	private final TransactionalOutboxPublisher transactionalOutboxPublisher;
 
+	/**
+	 * 사용자의 시험 제출을 처리하는 메소드입니다.
+	 *
+	 * <p>구현 세부사항:
+	 * <ul>
+	 *   <li>지정된 {@code assessmentId}에 대해 {@code Assessment} 엔티티를
+	 *       비관적 잠금(PESSIMISTIC_WRITE, X-Lock)으로 조회합니다.
+	 *       <br>- 이를 통해 여러 사용자가 동시에 제출할 때
+	 *       {@code distinctTriedMemberCount} 증가 연산의 경쟁 조건을 방지합니다.</li>
+	 *
+	 *   <li>해당 사용자가 처음 제출하는 경우 {@code distinctTriedMemberCount}를 증가시킵니다.
+	 *       <br>- {@code Submission}은 수십만 건 이상 누적될 수 있으므로,
+	 *       전체 컬렉션을 메모리에 로드하지 않고,
+	 *       특정 사용자 제출 여부만 단일 쿼리(S-Lock, FOR SHARE)로 확인합니다.</li>
+	 *
+	 *   <li>{@code AssessmentSubmission}을 생성하여 {@code Assessment} 엔티티에 등록합니다.</li>
+	 *
+	 *   <li>제출이 성공적으로 등록되면,
+	 *       Outbox 패턴을 통해 {@code assessment-submission-registered} 이벤트를 발행합니다.
+	 *       <br>- 이벤트에는 제출 ID, 제출 시간, distinct 제출자 수 등 메타데이터가 포함됩니다.</li>
+	 * </ul>
+	 *
+	 * @param command 제출 요청을 담은 DTO
+	 * @return 새로 생성된 {@code AssessmentSubmission}의 ID
+	 * @throws NoSuchAssessmentException 지정된 {@code assessmentId}에 해당하는 시험이 없을 경우 발생
+	 */
 	@Transactional
 	public Long submit(@NotNull @Valid final SubmissionRegisterCommand command) {
-		final Assessment assessment = assessmentRepository.findWithItems(command.assessmentId())
+		// X-Lock
+		final Assessment assessment = assessmentRepository.findWithItemsForUpdate(command.assessmentId())
 			.orElseThrow(() -> {
 				log.info("[SubmissionRegisterService.submit] cannot found assessment - assessmentId: {}",
 					command.assessmentId());
 				return new NoSuchAssessmentException();
 			});
+
+		// 처음으로 제출한 사용자일때
+		if (isFirstTry(command.assessmentId(), command.memberId())) {
+			assessment.increaseDistinctMemberCount();
+		}
+
+		// 새로운 답안지 등록
 		final AssessmentSubmission assessmentSubmission = assessment.registerSubmission(
 			command.memberId(),
 			command.submittedAnswers(),
 			command.elapsedTime()
 		);
-		assessmentSubmissionRepository.save(assessmentSubmission);
 
 		transactionalOutboxPublisher.publish("assessment-submission-registered", new SubmissionRegisteredEvent(
 			assessment.getId(),
 			command.memberId(),
 			assessmentSubmission.getId(),
 			assessmentSubmission.getSubmittedAt(),
+			assessment.getDistinctTriedMemberCount(),
 			assessmentSubmission.getElapsedTime().getSeconds()
 		));
 
 		return assessmentSubmission.getId();
+	}
+
+	/**
+	 * 특정 사용자가 해당 assessment에 대해 최초로 제출하는지 여부 확인
+	 * - Submission은 수십만 건 이상으로 증가할 수 있음
+	 * - 따라서 연관관계를 전부 메모리 로딩하지 않고,
+	 *   특정 사용자 기준으로 제한된 수(최대 약 100건)만 단일 쿼리로 조회
+	 * - 조회 시 S-Lock(PESSIMISTIC_READ, FOR SHARE)을 걸어 최신 커밋 기준으로 판별
+	 */
+	private boolean isFirstTry(final Long assessmentId, final Long memberId) {
+		return assessmentSubmissionRepository.findAllByAssessmentIdAndMemberIdForShare(assessmentId, memberId).isEmpty();
 	}
 
 	record SubmissionRegisteredEvent(
@@ -60,6 +105,7 @@ public class SubmissionRegisterService {
 		Long memberId,
 		Long submissionId,
 		LocalDateTime submittedTime,
+		Long distinctTriedMemberCount,
 		Long elapsedTimeSeconds
 	) implements EventPayload {
 	}

--- a/domain/mathrank-problem-assessment-domain/src/test/java/kr/co/mathrank/domain/problem/assessment/service/SubmissionRegisterServiceTest.java
+++ b/domain/mathrank-problem-assessment-domain/src/test/java/kr/co/mathrank/domain/problem/assessment/service/SubmissionRegisterServiceTest.java
@@ -1,0 +1,209 @@
+package kr.co.mathrank.domain.problem.assessment.service;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import kr.co.mathrank.client.internal.problem.ProblemClient;
+import kr.co.mathrank.common.role.Role;
+import kr.co.mathrank.domain.problem.assessment.dto.AssessmentItemRegisterCommand;
+import kr.co.mathrank.domain.problem.assessment.dto.AssessmentRegisterCommand;
+import kr.co.mathrank.domain.problem.assessment.dto.SubmissionRegisterCommand;
+import kr.co.mathrank.domain.problem.assessment.repository.AssessmentRepository;
+import kr.co.mathrank.domain.problem.assessment.repository.AssessmentSubmissionRepository;
+import kr.co.mathrank.domain.problem.core.Difficulty;
+
+@SpringBootTest(properties = """
+	spring.jpa.show-sql=true
+	spring.jpa.properties.hibernate.format_sql=true
+	spring.jpa.hibernate.ddl-auto=create
+	""")
+@Testcontainers
+class SubmissionRegisterServiceTest {
+	@Autowired
+	private SubmissionRegisterService submissionRegisterService;
+	@Autowired
+	private AssessmentRegisterService assessmentRegisterService;
+	@MockitoBean
+	private ProblemClient problemClient;
+	@Autowired
+	private AssessmentRepository assessmentRepository;
+
+	@Container
+	static MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0.42")
+		.withDatabaseName("testdb")
+		.withUsername("user")
+		.withPassword("password");
+	@Autowired
+	private AssessmentSubmissionRepository assessmentSubmissionRepository;
+
+	@DynamicPropertySource
+	static void setProperties(DynamicPropertyRegistry registry) {
+		registry.add("spring.datasource.url", mysql::getJdbcUrl);
+		registry.add("spring.datasource.username", mysql::getUsername);
+		registry.add("spring.datasource.password", mysql::getPassword);
+	}
+
+	@Test
+	void 같은_사용자가_동시에_여러번_제출할때_모든_답안지_정상등록() throws InterruptedException {
+		final Long assessmentId = assessmentRegisterService.register(new AssessmentRegisterCommand(
+			1L, Role.ADMIN,
+			"testName",
+			List.of(new AssessmentItemRegisterCommand(1L, 100)),
+			Difficulty.KILLER,
+			Duration.ofMinutes(100L)
+		));
+
+		final int tryCount = 20;
+
+		final ExecutorService executorService = Executors.newFixedThreadPool(10);
+		final CountDownLatch latch = new CountDownLatch(tryCount);
+		final Long memberId = 10L;
+
+		for (int i = 0; i < tryCount; i++) {
+			executorService.submit(() -> {
+				try {
+					submissionRegisterService.submit(
+						new SubmissionRegisterCommand(memberId, assessmentId, List.of(List.of("test")),
+							Duration.ofMinutes(1L)));
+				} finally {
+					latch.countDown();
+				}
+			});
+		}
+
+		latch.await();
+
+		// 제출된 답안지는 trCount와 같아야한다
+		Assertions.assertEquals(tryCount, assessmentSubmissionRepository.count());
+	}
+
+	@Test
+	void 서로다른_사용자가_동시에_여러번_제출할때_모든_답안지_정상등록() throws InterruptedException {
+		final Long assessmentId = assessmentRegisterService.register(new AssessmentRegisterCommand(
+			1L, Role.ADMIN,
+			"testName",
+			List.of(new AssessmentItemRegisterCommand(1L, 100)),
+			Difficulty.KILLER,
+			Duration.ofMinutes(100L)
+		));
+
+		final int tryCount = 20;
+
+		final ExecutorService executorService = Executors.newFixedThreadPool(10);
+		final CountDownLatch latch = new CountDownLatch(tryCount);
+
+		for (int i = 0; i < tryCount; i++) {
+			final Long memberId = (long) i;
+			executorService.submit(() -> {
+				try {
+					submissionRegisterService.submit(
+						new SubmissionRegisterCommand(memberId, assessmentId, List.of(List.of("test")),
+							Duration.ofMinutes(1L)));
+				} finally {
+					latch.countDown();
+				}
+			});
+		}
+
+		latch.await();
+
+		// 제출된 답안지는 trCount와 같아야한다
+		Assertions.assertEquals(tryCount, assessmentSubmissionRepository.count());
+	}
+
+	@Test
+	void 동일한_사용자가_답안지_여러번_제출시_한번만_카운트() throws InterruptedException {
+		final Long assessmentId = assessmentRegisterService.register(new AssessmentRegisterCommand(
+			1L, Role.ADMIN,
+			"testName",
+			List.of(new AssessmentItemRegisterCommand(1L, 100)),
+			Difficulty.KILLER,
+			Duration.ofMinutes(100L)
+		));
+
+		final int tryCount = 10;
+
+		// 두명의 사용자
+		final Long memberId1 = 10L;
+		final Long memberId2 = 11L;
+
+		final ExecutorService executorService = Executors.newFixedThreadPool(10);
+		final CountDownLatch latch = new CountDownLatch(tryCount);
+
+		for (int i = 0; i < tryCount; i++) {
+			final int value = i % 2;
+			executorService.submit(() -> {
+				try {
+					if (value == 0)  {
+						submissionRegisterService.submit(
+							new SubmissionRegisterCommand(memberId1, assessmentId, List.of(List.of("test")),
+								Duration.ofMinutes(1L)));
+					} else {
+						submissionRegisterService.submit(
+							new SubmissionRegisterCommand(memberId2, assessmentId, List.of(List.of("test")),
+								Duration.ofMinutes(1L)));
+					}
+				} finally {
+					latch.countDown();
+				}
+			});
+		}
+
+		latch.await();
+
+		Assertions.assertEquals(2, assessmentRepository.findById(assessmentId).get().getDistinctTriedMemberCount());
+	}
+
+	@Test
+	void 여러_사용자가_동시에_답안지_제출시_정확하게_카운트() throws InterruptedException {
+		final Long assessmentId = assessmentRegisterService.register(new AssessmentRegisterCommand(
+			1L, Role.ADMIN,
+			"testName",
+			List.of(new AssessmentItemRegisterCommand(1L, 100)),
+			Difficulty.KILLER,
+			Duration.ofMinutes(100L)
+		));
+
+		final int tryCount = 10;
+
+		final ExecutorService executorService = Executors.newFixedThreadPool(10);
+		final CountDownLatch latch = new CountDownLatch(tryCount);
+
+		for (int i = 0; i < tryCount; i++) {
+			final Long memberId = (long) i;
+			executorService.submit(() -> {
+				try {
+					submissionRegisterService.submit(
+						new SubmissionRegisterCommand(memberId, assessmentId, List.of(List.of("test")),
+							Duration.ofMinutes(1L)));
+				} finally {
+					latch.countDown();
+				}
+			});
+		}
+
+		latch.await();
+
+		Assertions.assertEquals(tryCount, assessmentRepository.findById(assessmentId).get().getDistinctTriedMemberCount());
+	}
+
+	@AfterEach
+	void clear() {
+		assessmentRepository.deleteAll();
+	}
+}


### PR DESCRIPTION
- `Lock` 범위 조정
상대적으로 개수가 제한적인 `item` 은 `fetch join` 으로 함께 로드하여 효율적으로 조회.
반면, `submission` 은 수만 ~ 수십만 건까지 증가할 수 있으므로, 모두 로드하지 않고 필요한 풀이 기록만 조회하도록 설계.
- `S-Lock` 활용
풀이 기록 조회 시에는 `S-Lock`을 적용하여 최신 커밋 데이터를 읽도록 함.
이를 통해, 불필요한 전체 엔티티 로드 X -> 메모리 확보.
  - 인덱스 적용
- 동시성 테스트 구성
위 전략이 의도한 대로 동작하는지 확인하기 위해 다중 스레드 동시 제출/조회 시나리오 기반의 동시성 테스트를 구성.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Assessments now track and update the count of unique members who attempted them.
* **Bug Fixes**
  * Improved concurrency handling for submission registration to ensure accurate distinct participant counts.
* **Performance**
  * Faster submission lookups for member-assessment queries.
* **Tests**
  * Added containerized integration tests validating concurrent submissions and distinct participant counting.
* **Chores**
  * Added test dependencies to support containerized integration testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->