### PR TITLE
단일 문제집 조회 API 구성 

### DIFF
--- a/app/api/mathrank-problem-assessment-read-api/build.gradle
+++ b/app/api/mathrank-problem-assessment-read-api/build.gradle
@@ -6,4 +6,5 @@ dependencies {
 
     implementation project(':app:api:mathrank-api-common')
     implementation project(':domain:mathrank-problem-assessment-domain')
+    implementation project(':domain:mathrank-problem-assessment-read-domain')
 }

--- a/app/api/mathrank-problem-assessment-read-api/src/main/java/kr/co/mathrank/app/api/problem/assessment/AssessmentReadController.java
+++ b/app/api/mathrank-problem-assessment-read-api/src/main/java/kr/co/mathrank/app/api/problem/assessment/AssessmentReadController.java
@@ -5,6 +5,7 @@ import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -14,6 +15,8 @@ import kr.co.mathrank.app.api.common.authentication.Authorization;
 import kr.co.mathrank.domain.problem.assessment.dto.AssessmentQuery;
 import kr.co.mathrank.domain.problem.assessment.dto.AssessmentQueryPageResult;
 import kr.co.mathrank.domain.problem.assessment.dto.AssessmentSubmissionQueryResult;
+import kr.co.mathrank.domain.problem.assessment.read.dto.AssessmentDetailReadModelResult;
+import kr.co.mathrank.domain.problem.assessment.read.service.AssessmentDetailReadService;
 import kr.co.mathrank.domain.problem.assessment.service.AssessmentQueryService;
 import kr.co.mathrank.domain.problem.assessment.service.SubmissionQueryService;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +27,8 @@ import lombok.RequiredArgsConstructor;
 public class AssessmentReadController {
 	private final AssessmentQueryService assessmentQueryService;
 	private final SubmissionQueryService submissionQueryService;
+
+	private final AssessmentDetailReadService assessmentDetailReadService;
 
 	@Operation(summary = "제출된 답안지 채점 상태 조회 API")
 	@Authorization(openedForAll = true)
@@ -43,5 +48,12 @@ public class AssessmentReadController {
 		@RequestParam(defaultValue = "1") @Range(min = 1, max = 1000) final Integer pageNumber
 	) {
 		return ResponseEntity.ok(assessmentQueryService.pageQuery(assessmentQuery, pageSize, pageNumber));
+	}
+
+	@Operation(summary = "문제집 상세 조회 API")
+	@Authorization(openedForAll = true)
+	@GetMapping("/api/v1/problem/assessment/{assessmentId}")
+	public ResponseEntity<AssessmentDetailReadModelResult> getDetail(@PathVariable final Long assessmentId) {
+		return ResponseEntity.ok(assessmentDetailReadService.getDetail(assessmentId));
 	}
 }

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/dto/AssessmentDetailResult.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/dto/AssessmentDetailResult.java
@@ -1,0 +1,33 @@
+package kr.co.mathrank.domain.problem.assessment.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import kr.co.mathrank.domain.problem.assessment.entity.Assessment;
+import kr.co.mathrank.domain.problem.core.Difficulty;
+
+public record AssessmentDetailResult(
+	Long assessmentId,
+	List<AssessmentItemDetail> itemDetails,
+	Long memberId,
+	String assessmentName,
+	Long distinctUserCount,
+	LocalDateTime createdAt,
+	Difficulty difficulty,
+	Long minutes
+) {
+	public static AssessmentDetailResult from(final Assessment assessment) {
+		return new AssessmentDetailResult(
+			assessment.getId(),
+			assessment.getAssessmentItems().stream()
+				.map(AssessmentItemDetail::from)
+				.toList(),
+			assessment.getRegisterMemberId(),
+			assessment.getAssessmentName(),
+			assessment.getDistinctTriedMemberCount(),
+			assessment.getCreatedAt(),
+			assessment.getDifficulty(),
+			assessment.getAssessmentDuration().toMinutes()
+		);
+	}
+}

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/dto/AssessmentItemDetail.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/dto/AssessmentItemDetail.java
@@ -1,0 +1,17 @@
+package kr.co.mathrank.domain.problem.assessment.dto;
+
+import kr.co.mathrank.domain.problem.assessment.entity.AssessmentItem;
+
+public record AssessmentItemDetail(
+	Long problemId,
+	Integer sequence,
+	Integer score
+) {
+	public static AssessmentItemDetail from(AssessmentItem assessmentItem) {
+		return new AssessmentItemDetail(
+			assessmentItem.getProblemId(),
+			assessmentItem.getSequence(),
+			assessmentItem.getScore()
+		);
+	}
+}

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/repository/AssessmentRepository.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/repository/AssessmentRepository.java
@@ -18,4 +18,11 @@ public interface AssessmentRepository extends JpaRepository<Assessment, Long>, A
 		""")
 	@Lock(LockModeType.PESSIMISTIC_WRITE)
 	Optional<Assessment> findWithItemsForUpdate(@Param("assessmentId") final Long assessmentId);
+
+	@Query("""
+		SELECT ass FROM Assessment ass
+				 LEFT JOIN FETCH ass.assessmentItems
+						  WHERE ass.id = :assessmentId
+		""")
+	Optional<Assessment> findWithItems(@Param("assessmentId") final Long assessmentId);
 }

--- a/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/service/AssessmentQueryService.java
+++ b/domain/mathrank-problem-assessment-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/service/AssessmentQueryService.java
@@ -8,17 +8,32 @@ import org.springframework.validation.annotation.Validated;
 
 import jakarta.validation.constraints.NotNull;
 import kr.co.mathrank.common.page.PageUtil;
+import kr.co.mathrank.domain.problem.assessment.dto.AssessmentDetailResult;
 import kr.co.mathrank.domain.problem.assessment.dto.AssessmentQuery;
 import kr.co.mathrank.domain.problem.assessment.dto.AssessmentQueryPageResult;
 import kr.co.mathrank.domain.problem.assessment.entity.Assessment;
+import kr.co.mathrank.domain.problem.assessment.exception.NoSuchAssessmentException;
 import kr.co.mathrank.domain.problem.assessment.repository.AssessmentRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @Validated
 @RequiredArgsConstructor
 public class AssessmentQueryService {
 	private final AssessmentRepository assessmentRepository;
+
+	public AssessmentDetailResult getAssessmentDetails(@NotNull final Long assessmentId) {
+		final Assessment assessment = assessmentRepository.findWithItems(assessmentId)
+			.orElseThrow(() -> {
+				log.info("[AssessmentQueryService.getAssessmentDetails] cannot found assessment - assessmentId: {}",
+					assessmentId);
+				return new NoSuchAssessmentException();
+			});
+		return AssessmentDetailResult.from(assessment);
+
+	}
 
 	public AssessmentQueryPageResult pageQuery(
 		@NotNull final AssessmentQuery assessmentQuery,

--- a/domain/mathrank-problem-assessment-read-domain/build.gradle
+++ b/domain/mathrank-problem-assessment-read-domain/build.gradle
@@ -5,4 +5,6 @@ dependencies {
     implementation project(':domain:mathrank-problem-assessment-domain')
     implementation project(':client:internal:mathrank-problem-client')
     implementation project(':client:internal:mathrank-course-client')
+
+    implementation project(':common:mathrank-cache')
 }

--- a/domain/mathrank-problem-assessment-read-domain/build.gradle
+++ b/domain/mathrank-problem-assessment-read-domain/build.gradle
@@ -1,0 +1,8 @@
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    implementation project(':domain:mathrank-problem-assessment-domain')
+    implementation project(':client:internal:mathrank-problem-client')
+    implementation project(':client:internal:mathrank-course-client')
+}

--- a/domain/mathrank-problem-assessment-read-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/read/AssessmentReadDomainConfiguration.java
+++ b/domain/mathrank-problem-assessment-read-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/read/AssessmentReadDomainConfiguration.java
@@ -14,47 +14,21 @@ public class AssessmentReadDomainConfiguration {
 	public static final String ASSESSMENT_READ_MODEL_CACHE_NAME = "mathrank::assessment-read-domain::assessment";
 
 	@Bean
-	RequiredCacheSpec assessmentReadDomainProblemCacheSpec() { // problem cache 등록
-		return new RequiredCacheSpec() {
-			@Override
-			public String moduleName() {
-				return "assessment-read-domain";
-			}
-
-			@Override
-			public String cacheName() {
-				return PROBLEM_CACHE_NAME;
-			}
-
-			@Override
-			public Duration ttl() {
-				return Duration.ofSeconds(60);
-			}
-		};
+	RequiredCacheSpec assessmentReadDomainProblemCacheSpec() {
+		return createCacheSpec(PROBLEM_CACHE_NAME, Duration.ofSeconds(60));
 	}
 
 	@Bean
-	RequiredCacheSpec assessmentReadDomainCourseCacheSpec() { // problem cache 등록
-		return new RequiredCacheSpec() {
-			@Override
-			public String moduleName() {
-				return "assessment-read-domain";
-			}
-
-			@Override
-			public String cacheName() {
-				return COURSE_CACHE_NAME;
-			}
-
-			@Override
-			public Duration ttl() {
-				return Duration.ofSeconds(60);
-			}
-		};
+	RequiredCacheSpec assessmentReadDomainCourseCacheSpec() {
+		return createCacheSpec(COURSE_CACHE_NAME, Duration.ofSeconds(60));
 	}
 
 	@Bean
-	RequiredCacheSpec assessmentReadDomainAssessmentCacheSpec() { // problem cache 등록
+	RequiredCacheSpec assessmentReadDomainAssessmentCacheSpec() {
+		return createCacheSpec(ASSESSMENT_READ_MODEL_CACHE_NAME, Duration.ofSeconds(60));
+	}
+
+	private RequiredCacheSpec createCacheSpec(final String cacheName, final Duration ttl) {
 		return new RequiredCacheSpec() {
 			@Override
 			public String moduleName() {
@@ -63,12 +37,12 @@ public class AssessmentReadDomainConfiguration {
 
 			@Override
 			public String cacheName() {
-				return ASSESSMENT_READ_MODEL_CACHE_NAME;
+				return cacheName;
 			}
 
 			@Override
 			public Duration ttl() {
-				return Duration.ofSeconds(60);
+				return ttl;
 			}
 		};
 	}

--- a/domain/mathrank-problem-assessment-read-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/read/AssessmentReadDomainConfiguration.java
+++ b/domain/mathrank-problem-assessment-read-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/read/AssessmentReadDomainConfiguration.java
@@ -11,6 +11,7 @@ import kr.co.mathrank.common.cache.RequiredCacheSpec;
 public class AssessmentReadDomainConfiguration {
 	public static final String PROBLEM_CACHE_NAME = "mathrank::assessment-read-domain::problem";
 	public static final String COURSE_CACHE_NAME = "mathrank::assessment-read-domain::course";
+	public static final String ASSESSMENT_READ_MODEL_CACHE_NAME = "mathrank::assessment-read-domain::assessment";
 
 	@Bean
 	RequiredCacheSpec assessmentReadDomainProblemCacheSpec() { // problem cache 등록
@@ -43,6 +44,26 @@ public class AssessmentReadDomainConfiguration {
 			@Override
 			public String cacheName() {
 				return COURSE_CACHE_NAME;
+			}
+
+			@Override
+			public Duration ttl() {
+				return Duration.ofSeconds(60);
+			}
+		};
+	}
+
+	@Bean
+	RequiredCacheSpec assessmentReadDomainAssessmentCacheSpec() { // problem cache 등록
+		return new RequiredCacheSpec() {
+			@Override
+			public String moduleName() {
+				return "assessment-read-domain";
+			}
+
+			@Override
+			public String cacheName() {
+				return ASSESSMENT_READ_MODEL_CACHE_NAME;
 			}
 
 			@Override

--- a/domain/mathrank-problem-assessment-read-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/read/AssessmentReadDomainConfiguration.java
+++ b/domain/mathrank-problem-assessment-read-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/read/AssessmentReadDomainConfiguration.java
@@ -10,6 +10,8 @@ import kr.co.mathrank.common.cache.RequiredCacheSpec;
 @Configuration
 public class AssessmentReadDomainConfiguration {
 	public static final String PROBLEM_CACHE_NAME = "mathrank::assessment-read-domain::problem";
+	public static final String COURSE_CACHE_NAME = "mathrank::assessment-read-domain::course";
+
 	@Bean
 	RequiredCacheSpec assessmentReadDomainProblemCacheSpec() { // problem cache 등록
 		return new RequiredCacheSpec() {
@@ -21,6 +23,26 @@ public class AssessmentReadDomainConfiguration {
 			@Override
 			public String cacheName() {
 				return PROBLEM_CACHE_NAME;
+			}
+
+			@Override
+			public Duration ttl() {
+				return Duration.ofSeconds(60);
+			}
+		};
+	}
+
+	@Bean
+	RequiredCacheSpec assessmentReadDomainCourseCacheSpec() { // problem cache 등록
+		return new RequiredCacheSpec() {
+			@Override
+			public String moduleName() {
+				return "assessment-read-domain";
+			}
+
+			@Override
+			public String cacheName() {
+				return COURSE_CACHE_NAME;
 			}
 
 			@Override

--- a/domain/mathrank-problem-assessment-read-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/read/AssessmentReadDomainConfiguration.java
+++ b/domain/mathrank-problem-assessment-read-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/read/AssessmentReadDomainConfiguration.java
@@ -1,0 +1,32 @@
+package kr.co.mathrank.domain.problem.assessment.read;
+
+import java.time.Duration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import kr.co.mathrank.common.cache.RequiredCacheSpec;
+
+@Configuration
+public class AssessmentReadDomainConfiguration {
+	public static final String PROBLEM_CACHE_NAME = "mathrank::assessment-read-domain::problem";
+	@Bean
+	RequiredCacheSpec assessmentReadDomainProblemCacheSpec() { // problem cache 등록
+		return new RequiredCacheSpec() {
+			@Override
+			public String moduleName() {
+				return "assessment-read-domain";
+			}
+
+			@Override
+			public String cacheName() {
+				return PROBLEM_CACHE_NAME;
+			}
+
+			@Override
+			public Duration ttl() {
+				return Duration.ofSeconds(60);
+			}
+		};
+	}
+}

--- a/domain/mathrank-problem-assessment-read-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/read/dto/AssessmentDetailReadModelResult.java
+++ b/domain/mathrank-problem-assessment-read-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/read/dto/AssessmentDetailReadModelResult.java
@@ -1,0 +1,31 @@
+package kr.co.mathrank.domain.problem.assessment.read.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import kr.co.mathrank.domain.problem.assessment.dto.AssessmentDetailResult;
+import kr.co.mathrank.domain.problem.core.Difficulty;
+
+public record AssessmentDetailReadModelResult(
+	Long assessmentId,
+	List<AssessmentItemReadModelDetailResult> itemDetails,
+	Long registeredMemberId,
+	String assessmentName,
+	Long distinctUserCount,
+	LocalDateTime createdAt,
+	Difficulty difficulty,
+	Long minutes
+) {
+	public static AssessmentDetailReadModelResult from(final AssessmentDetailResult detailResult, final List<AssessmentItemReadModelDetailResult> itemReadModelDetailResults) {
+		return new AssessmentDetailReadModelResult(
+			detailResult.assessmentId(),
+			itemReadModelDetailResults,
+			detailResult.memberId(),
+			detailResult.assessmentName(),
+			detailResult.distinctUserCount(),
+			detailResult.createdAt(),
+			detailResult.difficulty(),
+			detailResult.minutes()
+		);
+	}
+}

--- a/domain/mathrank-problem-assessment-read-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/read/dto/AssessmentItemReadModelDetailResult.java
+++ b/domain/mathrank-problem-assessment-read-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/read/dto/AssessmentItemReadModelDetailResult.java
@@ -1,0 +1,20 @@
+package kr.co.mathrank.domain.problem.assessment.read.dto;
+
+import java.time.LocalDateTime;
+
+import kr.co.mathrank.domain.problem.core.AnswerType;
+import kr.co.mathrank.domain.problem.core.Difficulty;
+
+public record AssessmentItemReadModelDetailResult(
+	Long problemId,
+	String problemImage,
+	Long memberId,
+	String path,
+	CourseDetailResult courseDetailResult,
+	Difficulty difficulty,
+	AnswerType type,
+	String schoolCode,
+	LocalDateTime createdAt,
+	Integer year
+) {
+}

--- a/domain/mathrank-problem-assessment-read-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/read/dto/CourseDetailResult.java
+++ b/domain/mathrank-problem-assessment-read-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/read/dto/CourseDetailResult.java
@@ -1,0 +1,13 @@
+package kr.co.mathrank.domain.problem.assessment.read.dto;
+
+import kr.co.mathrank.client.internal.course.CourseQueryResult;
+
+public record CourseDetailResult(
+	String coursePath,
+	String courseName
+) {
+	public static CourseDetailResult from(CourseQueryResult courseQueryResult) {
+		return new CourseDetailResult(courseQueryResult.coursePath(), courseQueryResult.courseName());
+	}
+
+}

--- a/domain/mathrank-problem-assessment-read-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/read/service/AssessmentDetailReadService.java
+++ b/domain/mathrank-problem-assessment-read-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/read/service/AssessmentDetailReadService.java
@@ -20,7 +20,7 @@ import lombok.RequiredArgsConstructor;
 public class AssessmentDetailReadService {
 	private final AssessmentQueryService assessmentQueryService;
 	private final ProblemQueryManager problemQueryManager;
-	private final CourseClient courseClient;
+	private final CourseQueryManager courseQueryManager;
 
 	public AssessmentDetailReadModelResult getDetail(@NotNull final Long assessmentId) {
 		final AssessmentDetailResult detailResult = assessmentQueryService.getAssessmentDetails(assessmentId);
@@ -33,8 +33,7 @@ public class AssessmentDetailReadService {
 
 	private AssessmentItemReadModelDetailResult mapToReadModel(final AssessmentItemDetail itemDetail) {
 		final ProblemQueryResult problemQueryResult = problemQueryManager.getProblemInfo(itemDetail.problemId());
-		final CourseQueryResult courseQueryResult = courseClient.getParentCourses(problemQueryResult.path())
-			.target();
+		final CourseQueryResult courseQueryResult = courseQueryManager.getCourseInfo(problemQueryResult.path());
 
 		return new AssessmentItemReadModelDetailResult(
 			itemDetail.problemId(),

--- a/domain/mathrank-problem-assessment-read-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/read/service/AssessmentDetailReadService.java
+++ b/domain/mathrank-problem-assessment-read-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/read/service/AssessmentDetailReadService.java
@@ -19,7 +19,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class AssessmentDetailReadService {
 	private final AssessmentQueryService assessmentQueryService;
-	private final ProblemClient problemClient;
+	private final ProblemQueryManager problemQueryManager;
 	private final CourseClient courseClient;
 
 	public AssessmentDetailReadModelResult getDetail(@NotNull final Long assessmentId) {
@@ -32,7 +32,7 @@ public class AssessmentDetailReadService {
 	}
 
 	private AssessmentItemReadModelDetailResult mapToReadModel(final AssessmentItemDetail itemDetail) {
-		final ProblemQueryResult problemQueryResult = problemClient.fetchProblemInfo(itemDetail.problemId());
+		final ProblemQueryResult problemQueryResult = problemQueryManager.getProblemInfo(itemDetail.problemId());
 		final CourseQueryResult courseQueryResult = courseClient.getParentCourses(problemQueryResult.path())
 			.target();
 

--- a/domain/mathrank-problem-assessment-read-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/read/service/AssessmentDetailReadService.java
+++ b/domain/mathrank-problem-assessment-read-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/read/service/AssessmentDetailReadService.java
@@ -1,14 +1,15 @@
 package kr.co.mathrank.domain.problem.assessment.read.service;
 
+import org.springframework.cache.annotation.CacheConfig;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import jakarta.validation.constraints.NotNull;
-import kr.co.mathrank.client.internal.course.CourseClient;
 import kr.co.mathrank.client.internal.course.CourseQueryResult;
-import kr.co.mathrank.client.internal.problem.ProblemClient;
 import kr.co.mathrank.client.internal.problem.ProblemQueryResult;
 import kr.co.mathrank.domain.problem.assessment.dto.AssessmentDetailResult;
 import kr.co.mathrank.domain.problem.assessment.dto.AssessmentItemDetail;
+import kr.co.mathrank.domain.problem.assessment.read.AssessmentReadDomainConfiguration;
 import kr.co.mathrank.domain.problem.assessment.read.dto.AssessmentDetailReadModelResult;
 import kr.co.mathrank.domain.problem.assessment.read.dto.AssessmentItemReadModelDetailResult;
 import kr.co.mathrank.domain.problem.assessment.read.dto.CourseDetailResult;
@@ -16,12 +17,14 @@ import kr.co.mathrank.domain.problem.assessment.service.AssessmentQueryService;
 import lombok.RequiredArgsConstructor;
 
 @Service
+@CacheConfig(cacheNames = AssessmentReadDomainConfiguration.ASSESSMENT_READ_MODEL_CACHE_NAME)
 @RequiredArgsConstructor
 public class AssessmentDetailReadService {
 	private final AssessmentQueryService assessmentQueryService;
 	private final ProblemQueryManager problemQueryManager;
 	private final CourseQueryManager courseQueryManager;
 
+	@Cacheable(key = "#assessmentId")
 	public AssessmentDetailReadModelResult getDetail(@NotNull final Long assessmentId) {
 		final AssessmentDetailResult detailResult = assessmentQueryService.getAssessmentDetails(assessmentId);
 		return AssessmentDetailReadModelResult.from(

--- a/domain/mathrank-problem-assessment-read-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/read/service/CourseQueryManager.java
+++ b/domain/mathrank-problem-assessment-read-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/read/service/CourseQueryManager.java
@@ -1,0 +1,25 @@
+package kr.co.mathrank.domain.problem.assessment.read.service;
+
+import org.springframework.cache.annotation.CacheConfig;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+import jakarta.validation.constraints.NotNull;
+import kr.co.mathrank.client.internal.course.CourseClient;
+import kr.co.mathrank.client.internal.course.CourseQueryResult;
+import kr.co.mathrank.domain.problem.assessment.read.AssessmentReadDomainConfiguration;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@Validated
+@RequiredArgsConstructor
+@CacheConfig(cacheNames = AssessmentReadDomainConfiguration.COURSE_CACHE_NAME)
+class CourseQueryManager {
+	private final CourseClient courseClient;
+
+	@Cacheable(key = "#coursePath")
+	public CourseQueryResult getCourseInfo(@NotNull final String coursePath) {
+		return courseClient.getParentCourses(coursePath).target();
+	}
+}

--- a/domain/mathrank-problem-assessment-read-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/read/service/ProblemQueryManager.java
+++ b/domain/mathrank-problem-assessment-read-domain/src/main/java/kr/co/mathrank/domain/problem/assessment/read/service/ProblemQueryManager.java
@@ -1,0 +1,25 @@
+package kr.co.mathrank.domain.problem.assessment.read.service;
+
+import org.springframework.cache.annotation.CacheConfig;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+import jakarta.validation.constraints.NotNull;
+import kr.co.mathrank.client.internal.problem.ProblemClient;
+import kr.co.mathrank.client.internal.problem.ProblemQueryResult;
+import kr.co.mathrank.domain.problem.assessment.read.AssessmentReadDomainConfiguration;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+@Validated
+@CacheConfig(cacheNames = AssessmentReadDomainConfiguration.PROBLEM_CACHE_NAME)
+class ProblemQueryManager {
+	private final ProblemClient problemClient;
+
+	@Cacheable(key = "#problemId")
+	public ProblemQueryResult getProblemInfo(@NotNull final Long problemId) {
+		return problemClient.fetchProblemInfo(problemId);
+	}
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -38,6 +38,7 @@ include(
         'domain',
         'domain:mathrank-course-domain',
         'domain:mathrank-problem-assessment-domain',
+        'domain:mathrank-problem-assessment-read-domain',
         'domain:mathrank-image-domain',
         'domain:mathrank-auth-domain',
         'domain:mathrank-problem-core-domain',


### PR DESCRIPTION
- 문제집 조회용 도메인 구성
- 각 클라이언트 모듈에 캐시 적용 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a GET endpoint to fetch detailed assessment info by ID, including item-level details enriched with problem and course metadata (image, path, difficulty, answer type, school/year), plus assessment name, creator, distinct user count, created time, and duration.
* **Performance**
  * Added caching for assessment details, problem data, and course data to improve repeat-request latency.
* **Chores**
  * Introduced a new read-domain module and wired required dependencies to support the read-model and API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->