### PR TITLE
feat(single-problem): 문제는 개별문제로 여러개 등록될 수 있다

### DIFF
--- a/domain/mathrank-problem-single-domain/src/main/java/kr/co/mathrank/domain/problem/single/entity/SingleProblem.java
+++ b/domain/mathrank-problem-single-domain/src/main/java/kr/co/mathrank/domain/problem/single/entity/SingleProblem.java
@@ -25,7 +25,7 @@ public class SingleProblem {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@Column(unique = true)
+	@Column
 	private Long problemId;
 
 	private String singleProblemName;

--- a/domain/mathrank-problem-single-domain/src/main/java/kr/co/mathrank/domain/problem/single/service/SingleProblemService.java
+++ b/domain/mathrank-problem-single-domain/src/main/java/kr/co/mathrank/domain/problem/single/service/SingleProblemService.java
@@ -47,14 +47,7 @@ public class SingleProblemService {
 		final ProblemQueryResult result = problemInfoManager.fetch(command.problemId());
 		final SingleProblem singleProblem = SingleProblem.of(command.problemId(), command.singleProblemName(), command.memberId());
 
-		try {
-			singleProblemRegisterManager.register(singleProblem, result);
-		} catch (DataIntegrityViolationException e) {
-			// 이미 등록된 문제는 다시 등록할 수 없다.
-			log.warn("[SingleProblemService.register] cannot register single problem duplicated: {}",
-				command.problemId(), e);
-			throw new AlreadyRegisteredProblemException();
-		}
+		singleProblemRegisterManager.register(singleProblem, result);
 		log.info("[SingleProblemService.register] single problem registered - singleProblemId: {}, problemId: {}", singleProblem.getId(), singleProblem.getProblemId());
 		return singleProblem.getId();
 	}

--- a/domain/mathrank-problem-single-domain/src/test/java/kr/co/mathrank/domain/problem/single/service/SingleProblemServiceTest.java
+++ b/domain/mathrank-problem-single-domain/src/test/java/kr/co/mathrank/domain/problem/single/service/SingleProblemServiceTest.java
@@ -68,13 +68,13 @@ class SingleProblemServiceTest {
 
 	@Test
 	@Transactional
-	void 이미_등록된_문제는_다시_등록할_수_없다() {
+	void 같은문제는_여러번_등록될_수_있다() {
 		final Long problemId = 1L;
 
 		Mockito.when(problemClient.fetchProblemInfo(Mockito.any())).thenReturn(getEmptyResult());
 
 		singleProblemService.register(new SingleProblemRegisterCommand(problemId, "test", 2L, Role.ADMIN));
-		Assertions.assertThrows(AlreadyRegisteredProblemException.class, () -> singleProblemService.register(new SingleProblemRegisterCommand(problemId, "test", 2L, Role.ADMIN)));
+		Assertions.assertDoesNotThrow(() -> singleProblemService.register(new SingleProblemRegisterCommand(problemId, "test", 2L, Role.ADMIN)));
 	}
 
 	@Test

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/entity/SingleProblemReadModel.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/entity/SingleProblemReadModel.java
@@ -34,6 +34,7 @@ import lombok.ToString;
 @Getter
 @Table(indexes = {
 	@Index(name = "idx_coursePath", columnList = "course_path"),
+	@Index(name = "idx_problemId", columnList = "problem_id"),
 	@Index(name = "idx_answerType", columnList = "answer_type"),
 	@Index(name = "idx_difficulty", columnList = "difficulty"),
 	@Index(name = "idx_totalAttemptedCount", columnList = "total_attempted_count"),

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/entity/SingleProblemReadModel.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/entity/SingleProblemReadModel.java
@@ -49,7 +49,7 @@ public class SingleProblemReadModel implements Persistable<Long> {
 	@Setter(AccessLevel.PRIVATE)
 	private Long id; // single problem id
 
-	@Column(unique = true, nullable = false)
+	@Column
 	@Setter(AccessLevel.PRIVATE)
 	private Long problemId; // problem id
 

--- a/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemReadModelRegisterService.java
+++ b/domain/mathrank-problem-single-read-domain/src/main/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemReadModelRegisterService.java
@@ -26,11 +26,6 @@ public class SingleProblemReadModelRegisterService {
 			command.difficulty(), 0L, 0L, 0L,
 			command.createdAt());
 
-		try {
-			singleProblemReadModelRepository.save(model);
-		} catch (DataIntegrityViolationException e) {
-			log.warn("[SingleProblemReadModelRegisterService.save] read model already exists: {}", model);
-			throw new SingleProblemReadModelAlreadyExistException();
-		}
+		singleProblemReadModelRepository.save(model);
 	}
 }

--- a/domain/mathrank-problem-single-read-domain/src/test/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemReadModelRegisterServiceTest.java
+++ b/domain/mathrank-problem-single-read-domain/src/test/java/kr/co/mathrank/domain/problem/single/read/service/SingleProblemReadModelRegisterServiceTest.java
@@ -16,7 +16,6 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import kr.co.mathrank.domain.problem.core.AnswerType;
 import kr.co.mathrank.domain.problem.core.Difficulty;
 import kr.co.mathrank.domain.problem.single.read.dto.SingleProblemReadModelRegisterCommand;
-import kr.co.mathrank.domain.problem.single.read.exception.SingleProblemReadModelAlreadyExistException;
 
 @SpringBootTest(
 	properties = {
@@ -45,17 +44,20 @@ class SingleProblemReadModelRegisterServiceTest {
 
 	@Test
 	@Transactional
-	void 중복삽입시_에러발생() {
+	void 중복삽입이_가능하다() {
+		final Long singleProblemId1 = 1L;
+		final Long singleProblemId2 = 2L;
 		final Long problemId = 1L;
 		final LocalDateTime baseTime = LocalDateTime.of(2018, 1, 1, 1, 1);
 
 		singleProblemReadModelRegisterService.save(new SingleProblemReadModelRegisterCommand(
-			problemId, problemId, "singleProblemName", "img", AnswerType.SHORT_ANSWER, Difficulty.LOW, "initialPath", baseTime
+			singleProblemId1, problemId, "singleProblemName", "img", AnswerType.SHORT_ANSWER, Difficulty.LOW, "initialPath", baseTime
 		));
 
-		Assertions.assertThrows(SingleProblemReadModelAlreadyExistException.class,
+		Assertions.assertDoesNotThrow(
 			() -> singleProblemReadModelRegisterService.save(new SingleProblemReadModelRegisterCommand(
-				problemId, problemId, "singleProblemName", "img", AnswerType.SHORT_ANSWER, Difficulty.LOW, "initialPath", baseTime
+				// 다른 singleProblemId
+				singleProblemId2, problemId, "singleProblemName", "img", AnswerType.SHORT_ANSWER, Difficulty.LOW, "initialPath", baseTime
 			)));
 	}
 }


### PR DESCRIPTION
- 각 `Problem`이 중복되어 등록될 수 있음 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - You can register the same problem multiple times; duplicates are allowed.
  - Read views now permit multiple records associated with the same problem ID.
- Bug Fixes
  - Removed duplicate-registration errors that were previously raised.
- Tests
  - Updated tests to assert that duplicate registrations and multiple read records are allowed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->